### PR TITLE
Учитывать ввод вывод ЦБ

### DIFF
--- a/src/main/java/ru/investbook/parser/SecurityTransaction.java
+++ b/src/main/java/ru/investbook/parser/SecurityTransaction.java
@@ -59,13 +59,15 @@ public class SecurityTransaction {
 
     public List<TransactionCashFlow> getTransactionCashFlows() {
         List<TransactionCashFlow> list = new ArrayList<>(3);
-        list.add(TransactionCashFlow.builder()
-                .transactionId(transactionId)
-                .portfolio(portfolio)
-                .eventType(CashFlowType.PRICE)
-                .value(value)
-                .currency(valueCurrency)
-                .build());
+        if (value.abs().compareTo(minValue) >= 0) {
+            list.add(TransactionCashFlow.builder()
+                    .transactionId(transactionId)
+                    .portfolio(portfolio)
+                    .eventType(CashFlowType.PRICE)
+                    .value(value)
+                    .currency(valueCurrency)
+                    .build());
+        }
         if (accruedInterest.abs().compareTo(minValue) >= 0) { // for securities accrued interest = 0
             list.add(TransactionCashFlow.builder()
                     .transactionId(transactionId)

--- a/src/main/java/ru/investbook/parser/WrappingReportTable.java
+++ b/src/main/java/ru/investbook/parser/WrappingReportTable.java
@@ -20,6 +20,7 @@ package ru.investbook.parser;
 
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -32,5 +33,14 @@ public class WrappingReportTable<RowType> implements ReportTable<RowType> {
     public WrappingReportTable(BrokerReport report, List<RowType> data) {
         this.report = report;
         this.data = Collections.unmodifiableList(data);
+    }
+
+    public WrappingReportTable(BrokerReport report, ReportTable<RowType>... tables) {
+        List<RowType> data = new ArrayList<>();
+        for (ReportTable<RowType> table : tables) {
+            data.addAll(table.getData());
+        }
+        this.report = report;
+        this.data = data;
     }
 }

--- a/src/main/java/ru/investbook/parser/uralsib/CouponAmortizationRedemptionTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/CouponAmortizationRedemptionTable.java
@@ -21,6 +21,8 @@ package ru.investbook.parser.uralsib;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.Row;
 import ru.investbook.parser.ExcelTable;
+import ru.investbook.parser.ReportTable;
+import ru.investbook.parser.SecurityTransaction;
 import ru.investbook.pojo.CashFlowType;
 import ru.investbook.pojo.Security;
 import ru.investbook.pojo.SecurityEventCashFlow;
@@ -44,7 +46,7 @@ public class CouponAmortizationRedemptionTable extends PaymentsTable<SecurityEve
 
     public CouponAmortizationRedemptionTable(UralsibBrokerReport report,
                                              PortfolioSecuritiesTable securitiesTable,
-                                             SecurityTransactionTable securityTransactionTable) {
+                                             ReportTable<SecurityTransaction> securityTransactionTable) {
         super(report, securitiesTable, securityTransactionTable);
         this.redemptionDates = new SecurityRedemptionTable(report).getData();
     }

--- a/src/main/java/ru/investbook/parser/uralsib/DividendTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/DividendTable.java
@@ -21,6 +21,8 @@ package ru.investbook.parser.uralsib;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.Row;
 import ru.investbook.parser.ExcelTable;
+import ru.investbook.parser.ReportTable;
+import ru.investbook.parser.SecurityTransaction;
 import ru.investbook.pojo.CashFlowType;
 import ru.investbook.pojo.Security;
 import ru.investbook.pojo.SecurityEventCashFlow;
@@ -45,7 +47,7 @@ public class DividendTable extends PaymentsTable<SecurityEventCashFlow> {
 
     public DividendTable(UralsibBrokerReport report,
                          PortfolioSecuritiesTable securitiesTable,
-                         SecurityTransactionTable securityTransactionTable) {
+                         ReportTable<SecurityTransaction> securityTransactionTable) {
         super(report, securitiesTable, securityTransactionTable);
     }
 

--- a/src/main/java/ru/investbook/parser/uralsib/PaymentsTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/PaymentsTable.java
@@ -48,7 +48,7 @@ abstract class PaymentsTable<RowType> extends AbstractReportTable<RowType> {
 
     public PaymentsTable(UralsibBrokerReport report,
                          PortfolioSecuritiesTable securitiesTable,
-                         SecurityTransactionTable securityTransactionTable) {
+                         ReportTable<SecurityTransaction> securityTransactionTable) {
         super(report, TABLE_NAME, "", PaymentsTableHeader.class);
         this.securitiesIncomingCount = securitiesTable.getData();
         this.securityTransactions = securityTransactionTable.getData();

--- a/src/main/java/ru/investbook/parser/uralsib/SecurityDepositAndWithdrawalTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/SecurityDepositAndWithdrawalTable.java
@@ -1,0 +1,76 @@
+/*
+ * InvestBook
+ * Copyright (C) 2020  Vitalii Ananev <an-vitek@ya.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ru.investbook.parser.uralsib;
+
+import org.apache.poi.ss.usermodel.Row;
+import ru.investbook.parser.AbstractReportTable;
+import ru.investbook.parser.ExcelTable;
+import ru.investbook.parser.SecurityTransaction;
+import ru.investbook.pojo.Security;
+
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static ru.investbook.parser.uralsib.SecurityRedemptionTable.SecurityFlowTableHeader.*;
+
+/**
+ * Ввод и вывод ценных бумаг со счета
+ */
+public class SecurityDepositAndWithdrawalTable extends AbstractReportTable<SecurityTransaction> {
+    private static final String TABLE_NAME = SecurityRedemptionTable.TABLE_NAME;
+    private static final String IN_DESCRIPTION = "ввод цб";
+    private static final String OUT_DESCRIPTION = "вывод цб";
+    private final List<PortfolioSecuritiesTable.ReportSecurityInformation> securitiesIncomingCount;
+
+    public SecurityDepositAndWithdrawalTable(UralsibBrokerReport report, PortfolioSecuritiesTable securitiesTable) {
+        super(report, TABLE_NAME, "", SecurityRedemptionTable.SecurityFlowTableHeader.class);
+        this.securitiesIncomingCount = securitiesTable.getData();
+    }
+
+    @Override
+    protected Collection<SecurityTransaction> getRow(ExcelTable table, Row row) {
+        String operation = table.getStringCellValue(row, OPERATION);
+        if (!operation.equalsIgnoreCase(IN_DESCRIPTION) && !operation.equalsIgnoreCase(OUT_DESCRIPTION)) {
+            return Collections.emptyList();
+        }
+        return Collections.singletonList(SecurityTransaction.builder()
+                .timestamp(convertToInstant(table.getStringCellValue(row, DATE)))
+                .transactionId(Long.parseLong(table.getStringCellValue(row, ID).replaceAll("\\D", "")))
+                .portfolio(getReport().getPortfolio())
+                .isin(getSecurity(table, row).getIsin())
+                .count(table.getIntCellValue(row, COUNT))
+                .value(BigDecimal.ZERO)
+                .accruedInterest(BigDecimal.ZERO)
+                .commission(BigDecimal.ZERO)
+                .valueCurrency("RUB")
+                .commissionCurrency("RUB")
+                .build());
+    }
+
+    private Security getSecurity(ExcelTable table, Row row) {
+        String cfi = table.getStringCellValue(row, CFI);
+        return securitiesIncomingCount.stream()
+                .filter(security -> security.getCfi().equals(cfi))
+                .map(PortfolioSecuritiesTable.ReportSecurityInformation::getSecurity)
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("Не могу найти ISIN для ЦБ с CFI = " + cfi));
+    }
+}

--- a/src/main/java/ru/investbook/parser/uralsib/SecurityRedemptionTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/SecurityRedemptionTable.java
@@ -29,17 +29,17 @@ import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static ru.investbook.parser.uralsib.SecurityRedemptionTable.SecurityRedemptionTableHeader.*;
+import static ru.investbook.parser.uralsib.SecurityRedemptionTable.SecurityFlowTableHeader.*;
 
 /**
  * Builds list of (security name; redemption date) tuples
  */
 public class SecurityRedemptionTable extends AbstractReportTable<Map.Entry<String, Instant>> {
-    private static final String TABLE_NAME = "ДВИЖЕНИЕ ЦЕННЫХ БУМАГ ЗА ОТЧЕТНЫЙ ПЕРИОД";
+    static final String TABLE_NAME = "ДВИЖЕНИЕ ЦЕННЫХ БУМАГ ЗА ОТЧЕТНЫЙ ПЕРИОД";
     private static final String REDEMPTION_DESCRIPTION = "Списание ЦБ после погашения";
 
     public SecurityRedemptionTable(UralsibBrokerReport report) {
-        super(report, TABLE_NAME, "", SecurityRedemptionTableHeader.class);
+        super(report, TABLE_NAME, "", SecurityFlowTableHeader.class);
     }
 
     @Override
@@ -51,15 +51,18 @@ public class SecurityRedemptionTable extends AbstractReportTable<Map.Entry<Strin
                 emptyList();
     }
 
-    enum SecurityRedemptionTableHeader implements TableColumnDescription {
+    enum SecurityFlowTableHeader implements TableColumnDescription {
+        ID("№", "операции"),
         OPERATION("тип операции"),
         DATE("дата"),
-        NAME("наименование");
+        NAME("наименование"),
+        CFI("номер гос. регистрации"),
+        COUNT("количество цб");
 
         @Getter
         private final TableColumn column;
 
-        SecurityRedemptionTableHeader(String... words) {
+        SecurityFlowTableHeader(String... words) {
             this.column = TableColumnImpl.of(words);
         }
     }

--- a/src/main/java/ru/investbook/parser/uralsib/UralsibReportTableFactory.java
+++ b/src/main/java/ru/investbook/parser/uralsib/UralsibReportTableFactory.java
@@ -35,7 +35,7 @@ public class UralsibReportTableFactory implements ReportTableFactory {
     private final UralsibBrokerReport report;
     private final PortfolioSecuritiesTable portfolioSecuritiesTable;
     @Getter
-    private final SecurityTransactionTable securityTransactionTable;
+    private final ReportTable<SecurityTransaction> securityTransactionTable;
     @Getter
     private final PortfolioPropertyTable portfolioPropertyTable;
     @Getter
@@ -47,7 +47,9 @@ public class UralsibReportTableFactory implements ReportTableFactory {
         this.report = report;
         this.portfolioPropertyTable = new PortfolioPropertyTable(report, foreignExchangeRateService);
         this.portfolioSecuritiesTable = new PortfolioSecuritiesTable(report);
-        this.securityTransactionTable = new SecurityTransactionTable(report, portfolioPropertyTable);
+        this.securityTransactionTable = new WrappingReportTable<>(report,
+                new SecurityTransactionTable(report, portfolioPropertyTable),
+                new SecurityDepositAndWithdrawalTable(report, portfolioSecuritiesTable));
         this.couponAmortizationRedemptionTable =
                 new CouponAmortizationRedemptionTable(report, portfolioSecuritiesTable, securityTransactionTable);
         this.dividendTable = new DividendTable(report, portfolioSecuritiesTable, securityTransactionTable);

--- a/src/main/java/ru/investbook/repository/TransactionRepository.java
+++ b/src/main/java/ru/investbook/repository/TransactionRepository.java
@@ -147,4 +147,10 @@ public interface TransactionRepository extends JpaRepository<TransactionEntity, 
             "AND count < 0")
     Long findBySecurityIsinAndPkPortfolioCellCount(@Param("security") Security security,
                                                    @Param("portfolio") Portfolio portfolio);
+
+    @Query("SELECT t FROM TransactionEntity t " +
+            "LEFT OUTER JOIN TransactionCashFlowEntity c " +
+            "ON t.pk.id = c.pk.transactionId AND t.pk.portfolio = c.pk.portfolio AND c.pk.type = 1 " +
+            "WHERE c.pk.type IS NULL AND t.pk.portfolio = :#{#portfolio.id}")
+    Collection<TransactionEntity> findDepositAndWithdrawalTransactions(@Param("portfolio") Portfolio portfolio);
 }

--- a/src/main/java/ru/investbook/view/excel/ExcelView.java
+++ b/src/main/java/ru/investbook/view/excel/ExcelView.java
@@ -31,6 +31,7 @@ public class ExcelView {
     private final StockMarketProfitExcelTableView stockMarketProfitExcelTableView;
     private final DerivativesMarketProfitExcelTableView derivativesMarketProfitExcelTableView;
     private final ForeignMarketProfitExcelTableView foreignMarketProfitExcelTableView;
+    private final SecuritiesDepositAndWithdrawalExcelTableView securitiesDepositAndWithdrawalExcelTableView;
     private final CashFlowExcelTableView cashFlowExcelTableView;
     private final TaxExcelTableView taxExcelTableView;
 
@@ -42,6 +43,7 @@ public class ExcelView {
         stockMarketProfitExcelTableView.writeTo(book, styles, portfolio -> portfolio + " (фондовый)");
         derivativesMarketProfitExcelTableView.writeTo(book, styles, portfolio -> portfolio + " (срочный)");
         foreignMarketProfitExcelTableView.writeTo(book, styles, portfolio -> portfolio + " (валюта)");
+        securitiesDepositAndWithdrawalExcelTableView.writeTo(book, styles, portfolio -> portfolio + " (ввод-вывод цб)");
         cashFlowExcelTableView.writeTo(book, styles, portfolio -> "Доходность (" + portfolio + ")");
         taxExcelTableView.writeTo(book, styles, portfolio -> "Налог (" + portfolio + ")");
         if (book.getNumberOfSheets() == 0) {

--- a/src/main/java/ru/investbook/view/excel/PortfolioStatusExcelTableFactory.java
+++ b/src/main/java/ru/investbook/view/excel/PortfolioStatusExcelTableFactory.java
@@ -130,7 +130,10 @@ public class PortfolioStatusExcelTableFactory implements TableFactory {
         row.put(CELL_COUNT, Optional.ofNullable(
                 transactionRepository.findBySecurityIsinAndPkPortfolioCellCount(security, portfolio))
                 .orElse(0L) +
-                positions.getRedemptions().size());
+                positions.getRedemptions()
+                        .stream()
+                        .mapToInt(SecurityEventCashFlow::getCount)
+                        .sum());
         int count = getCount(positions);
         row.put(COUNT, count);
         if (count == 0) {

--- a/src/main/java/ru/investbook/view/excel/SecuritiesDepositAndWithdrawalExcelTableFactory.java
+++ b/src/main/java/ru/investbook/view/excel/SecuritiesDepositAndWithdrawalExcelTableFactory.java
@@ -1,0 +1,52 @@
+/*
+ * InvestBook
+ * Copyright (C) 2020  Vitalii Ananev <an-vitek@ya.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ru.investbook.view.excel;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import ru.investbook.entity.TransactionEntity;
+import ru.investbook.pojo.Portfolio;
+import ru.investbook.repository.SecurityRepository;
+import ru.investbook.repository.TransactionRepository;
+import ru.investbook.view.Table;
+import ru.investbook.view.TableFactory;
+
+import static ru.investbook.view.excel.SecuritiesDepositAndWithdrawalExcelTableHeader.*;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SecuritiesDepositAndWithdrawalExcelTableFactory implements TableFactory {
+    private final TransactionRepository transactionRepository;
+    private final SecurityRepository securityRepository;
+
+    @Override
+    public Table create(Portfolio portfolio) {
+        Table table = new Table();
+        for (TransactionEntity transactionEntity : transactionRepository.findDepositAndWithdrawalTransactions(portfolio)) {
+            Table.Record record = new Table.Record();
+            table.add(record);
+            record.put(DATE, transactionEntity.getTimestamp());
+            record.put(COUNT, transactionEntity.getCount());
+            record.put(SECURITY, transactionEntity.getSecurity().getName());
+        }
+        return table;
+    }
+}

--- a/src/main/java/ru/investbook/view/excel/SecuritiesDepositAndWithdrawalExcelTableHeader.java
+++ b/src/main/java/ru/investbook/view/excel/SecuritiesDepositAndWithdrawalExcelTableHeader.java
@@ -1,0 +1,32 @@
+/*
+ * InvestBook
+ * Copyright (C) 2020  Vitalii Ananev <an-vitek@ya.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ru.investbook.view.excel;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SecuritiesDepositAndWithdrawalExcelTableHeader implements ExcelTableHeader {
+    SECURITY("Бумага"),
+    DATE("Дата"),
+    COUNT("Внесено (+) / Выведено (-)");
+
+    private final String description;
+}

--- a/src/main/java/ru/investbook/view/excel/SecuritiesDepositAndWithdrawalExcelTableView.java
+++ b/src/main/java/ru/investbook/view/excel/SecuritiesDepositAndWithdrawalExcelTableView.java
@@ -1,0 +1,83 @@
+/*
+ * InvestBook
+ * Copyright (C) 2020  Vitalii Ananev <an-vitek@ya.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ru.investbook.view.excel;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.springframework.stereotype.Component;
+import ru.investbook.converter.PortfolioConverter;
+import ru.investbook.repository.PortfolioPropertyRepository;
+import ru.investbook.repository.PortfolioRepository;
+import ru.investbook.view.Table;
+import ru.investbook.view.TableHeader;
+
+import static ru.investbook.view.excel.SecuritiesDepositAndWithdrawalExcelTableHeader.COUNT;
+import static ru.investbook.view.excel.SecuritiesDepositAndWithdrawalExcelTableHeader.SECURITY;
+
+@Component
+public class SecuritiesDepositAndWithdrawalExcelTableView extends ExcelTableView {
+
+    public SecuritiesDepositAndWithdrawalExcelTableView(PortfolioRepository portfolioRepository,
+                                                        SecuritiesDepositAndWithdrawalExcelTableFactory tableFactory,
+                                                        PortfolioConverter portfolioConverter,
+                                                        PortfolioPropertyRepository portfolioPropertyRepository) {
+        super(portfolioRepository, tableFactory, portfolioConverter);
+    }
+
+    @Override
+    protected void writeHeader(Sheet sheet, Class<? extends TableHeader> headerType, CellStyle style) {
+        super.writeHeader(sheet, headerType, style);
+        sheet.setColumnWidth(SECURITY.ordinal(), 45 * 256);
+        sheet.setColumnWidth(COUNT.ordinal(), 18 * 256);
+    }
+
+    @Override
+    protected Table.Record getTotalRow() {
+        Table.Record total = Table.newRecord();
+        total.put(SECURITY, "Итого:");
+        total.put(COUNT, "=SUM(" +
+                COUNT.getColumnIndex() + "3:" +
+                COUNT.getColumnIndex() + "100000)");
+        return total;
+    }
+
+    @Override
+    protected void sheetPostCreate(Sheet sheet, CellStyles styles) {
+        super.sheetPostCreate(sheet, styles);
+        for (Row row : sheet) {
+            if (row.getRowNum() == 0) continue;
+            Cell cell = row.getCell(SECURITY.ordinal());
+            if (cell != null) {
+                cell.setCellStyle(styles.getLeftAlignedTextStyle());
+            }
+        }
+        for (Cell cell : sheet.getRow(1)) {
+            if (cell == null) continue;
+            if (cell.getColumnIndex() == SECURITY.ordinal()) {
+                cell.setCellStyle(styles.getTotalTextStyle());
+            } else if (cell.getColumnIndex() == COUNT.ordinal()){
+                cell.setCellStyle(styles.getIntStyle());
+            } else {
+                cell.setCellStyle(styles.getTotalRowStyle());
+            }
+        }
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,8 +1,8 @@
 # ад MariaDB
-spring.datasource.url=jdbc:mysql://localhost:3306/portfolio?createDatabaseIfNotExist=true&serverTimezone=Europe/Moscow
+spring.datasource.url = jdbc:mysql://localhost:3306/portfolio?createDatabaseIfNotExist=true&serverTimezone=Europe/Moscow
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MariaDB102Dialect
-spring.datasource.username=root
-spring.datasource.password=123456
+spring.datasource.username = root
+spring.datasource.password = 123456
 
 # ад H2
 #spring.datasource.url=jdbc:h2:file:~/portfolio;mode=mysql


### PR DESCRIPTION
Учитывать ввод вывод ЦБ со счета Цралсиб брокера, добавить таблицу со списком таких бумаг, корректно рассчитывать усредненную цену покупки ЦБ при наличии ввода и вывода (введенные на счет ЦБ не влияют на финсансвый результат вне зависимости от цены продажи, аналогично для выведенных ЦБ). Пофикшен баг расчета проданных облигаций для таблицы статуса портфеля при наличии погашения.
Closes gh-65.