### PR TITLE
Исправление фильтрации в excel отчете

### DIFF
--- a/src/main/java/ru/investbook/view/excel/CashFlowExcelTableView.java
+++ b/src/main/java/ru/investbook/view/excel/CashFlowExcelTableView.java
@@ -80,8 +80,8 @@ public class CashFlowExcelTableView extends ExcelTableView {
     }
 
     @Override
-    protected void sheetPostCreate(Sheet sheet, CellStyles styles) {
-        super.sheetPostCreate(sheet, styles);
+    protected void sheetPostCreate(Sheet sheet, Class<? extends TableHeader> headerType, CellStyles styles) {
+        super.sheetPostCreate(sheet, headerType, styles);
         for (Row row : sheet) {
             if (row.getRowNum() == 0) continue;
             Cell cell = row.getCell(DAYS_COUNT.ordinal());

--- a/src/main/java/ru/investbook/view/excel/DerivativesMarketProfitExcelTableView.java
+++ b/src/main/java/ru/investbook/view/excel/DerivativesMarketProfitExcelTableView.java
@@ -76,8 +76,8 @@ public class DerivativesMarketProfitExcelTableView extends ExcelTableView {
     }
 
     @Override
-    protected void sheetPostCreate(Sheet sheet, CellStyles styles) {
-        super.sheetPostCreate(sheet, styles);
+    protected void sheetPostCreate(Sheet sheet, Class<? extends TableHeader> headerType, CellStyles styles) {
+        super.sheetPostCreate(sheet, headerType, styles);
         for (Row row : sheet) {
             if (row.getRowNum() == 0) continue;
             Cell cell = row.getCell(CONTRACT.ordinal());

--- a/src/main/java/ru/investbook/view/excel/ExcelTableView.java
+++ b/src/main/java/ru/investbook/view/excel/ExcelTableView.java
@@ -122,7 +122,7 @@ public abstract class ExcelTableView {
                 }
             }
         }
-        sheetPostCreate(sheet, styles);
+        sheetPostCreate(sheet, headerType, styles);
     }
 
     private Class<? extends TableHeader> getHeaderType(Table table) {
@@ -146,14 +146,14 @@ public abstract class ExcelTableView {
             sheet.setColumnWidth(header.ordinal(), 14 * 256);
         }
         sheet.createFreezePane(0, 1);
-        sheet.setAutoFilter(new CellRangeAddress(0, 0, 0, (headerType.getEnumConstants().length - 1)));
     }
 
     protected Table.Record getTotalRow() {
         return new Table.Record();
     }
 
-    protected void sheetPostCreate(Sheet sheet, CellStyles styles) {
+    protected void sheetPostCreate(Sheet sheet, Class<? extends TableHeader> headerType, CellStyles styles) {
         sheet.setZoom(93); // show all columns for 24 inch monitor for securities sheet
+        sheet.setAutoFilter(new CellRangeAddress(0, sheet.getLastRowNum(), 0, (headerType.getEnumConstants().length - 1)));
     }
 }

--- a/src/main/java/ru/investbook/view/excel/ForeignMarketProfitExcelTableView.java
+++ b/src/main/java/ru/investbook/view/excel/ForeignMarketProfitExcelTableView.java
@@ -68,8 +68,8 @@ public class ForeignMarketProfitExcelTableView extends ExcelTableView {
     }
 
     @Override
-    protected void sheetPostCreate(Sheet sheet, CellStyles styles) {
-        super.sheetPostCreate(sheet, styles);
+    protected void sheetPostCreate(Sheet sheet, Class<? extends TableHeader> headerType, CellStyles styles) {
+        super.sheetPostCreate(sheet, headerType, styles);
         for (Row row : sheet) {
             if (row.getRowNum() == 0) continue;
             Cell cell = row.getCell(CURRENCY_PAIR.ordinal());

--- a/src/main/java/ru/investbook/view/excel/ForeignPortfolioPaymentTableView.java
+++ b/src/main/java/ru/investbook/view/excel/ForeignPortfolioPaymentTableView.java
@@ -57,8 +57,8 @@ public class ForeignPortfolioPaymentTableView extends ExcelTableView {
     }
 
     @Override
-    protected void sheetPostCreate(Sheet sheet, CellStyles styles) {
-        super.sheetPostCreate(sheet, styles);
+    protected void sheetPostCreate(Sheet sheet, Class<? extends TableHeader> headerType, CellStyles styles) {
+        super.sheetPostCreate(sheet, headerType, styles);
         for (Row row : sheet) {
             if (row.getRowNum() == 0) continue;
             Cell cell = row.getCell(DESCRIPTION.ordinal());

--- a/src/main/java/ru/investbook/view/excel/PortfolioPaymentTableView.java
+++ b/src/main/java/ru/investbook/view/excel/PortfolioPaymentTableView.java
@@ -61,8 +61,8 @@ public class PortfolioPaymentTableView extends ExcelTableView {
     }
 
     @Override
-    protected void sheetPostCreate(Sheet sheet, CellStyles styles) {
-        super.sheetPostCreate(sheet, styles);
+    protected void sheetPostCreate(Sheet sheet, Class<? extends TableHeader> headerType, CellStyles styles) {
+        super.sheetPostCreate(sheet, headerType, styles);
         for (Row row : sheet) {
             if (row.getRowNum() == 0) continue;
             Cell cell = row.getCell(SECURITY.ordinal());

--- a/src/main/java/ru/investbook/view/excel/PortfolioStatusExcelTableView.java
+++ b/src/main/java/ru/investbook/view/excel/PortfolioStatusExcelTableView.java
@@ -94,8 +94,8 @@ public class PortfolioStatusExcelTableView extends ExcelTableView {
     }
 
     @Override
-    protected void sheetPostCreate(Sheet sheet, CellStyles styles) {
-        super.sheetPostCreate(sheet, styles);
+    protected void sheetPostCreate(Sheet sheet, Class<? extends TableHeader> headerType, CellStyles styles) {
+        super.sheetPostCreate(sheet, headerType, styles);
         for (Row row : sheet) {
             if (row.getRowNum() == 0) continue;
             Cell cell = row.getCell(SECURITY.ordinal());

--- a/src/main/java/ru/investbook/view/excel/SecuritiesDepositAndWithdrawalExcelTableView.java
+++ b/src/main/java/ru/investbook/view/excel/SecuritiesDepositAndWithdrawalExcelTableView.java
@@ -60,8 +60,8 @@ public class SecuritiesDepositAndWithdrawalExcelTableView extends ExcelTableView
     }
 
     @Override
-    protected void sheetPostCreate(Sheet sheet, CellStyles styles) {
-        super.sheetPostCreate(sheet, styles);
+    protected void sheetPostCreate(Sheet sheet, Class<? extends TableHeader> headerType, CellStyles styles) {
+        super.sheetPostCreate(sheet, headerType, styles);
         for (Row row : sheet) {
             if (row.getRowNum() == 0) continue;
             Cell cell = row.getCell(SECURITY.ordinal());

--- a/src/main/java/ru/investbook/view/excel/StockMarketProfitExcelTableView.java
+++ b/src/main/java/ru/investbook/view/excel/StockMarketProfitExcelTableView.java
@@ -91,8 +91,8 @@ public class StockMarketProfitExcelTableView extends ExcelTableView {
     }
 
     @Override
-    protected void sheetPostCreate(Sheet sheet, CellStyles styles) {
-        super.sheetPostCreate(sheet, styles);
+    protected void sheetPostCreate(Sheet sheet, Class<? extends TableHeader> headerType, CellStyles styles) {
+        super.sheetPostCreate(sheet, headerType, styles);
         for (Row row : sheet) {
             if (row.getRowNum() == 0) continue;
             Cell cell = row.getCell(SECURITY.ordinal());

--- a/src/main/java/ru/investbook/view/excel/TaxExcelTableView.java
+++ b/src/main/java/ru/investbook/view/excel/TaxExcelTableView.java
@@ -57,8 +57,8 @@ public class TaxExcelTableView extends ExcelTableView {
     }
 
     @Override
-    protected void sheetPostCreate(Sheet sheet, CellStyles styles) {
-        super.sheetPostCreate(sheet, styles);
+    protected void sheetPostCreate(Sheet sheet, Class<? extends TableHeader> headerType, CellStyles styles) {
+        super.sheetPostCreate(sheet, headerType, styles);
         for (Row row : sheet) {
             if (row.getRowNum() == 0) continue;
             Cell cell = row.getCell(DESCRIPTION.ordinal());


### PR DESCRIPTION
При наличии в таблице пустых строк фильтрация по колонке учитывала строки до первой пустой. Фикс исправил это, теперь учитываются все строки таблицы.