### PR TITLE
Не завершать приложение с ошибкой при повторном запуске

### DIFF
--- a/src/main/java/ru/investbook/ApplicationFailedRunListener.java
+++ b/src/main/java/ru/investbook/ApplicationFailedRunListener.java
@@ -1,0 +1,40 @@
+/*
+ * InvestBook
+ * Copyright (C) 2020  Vitalii Ananev <an-vitek@ya.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ru.investbook;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationFailedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+public class ApplicationFailedRunListener implements ApplicationListener<ApplicationFailedEvent> {
+
+    private final Logger log = LoggerFactory.getLogger(ApplicationFailedRunListener.class);
+
+    @Override
+    public void onApplicationEvent(ApplicationFailedEvent event) {
+        ConfigurableEnvironment environment = event.getApplicationContext().getEnvironment();
+        if (environment.getProperty("portfolio.open-home-page-after-start", Boolean.class, false)) {
+            log.info("Application run failed. May be application was run a second time, trying to open the application page...");
+            int port = environment.getProperty("server.port", Integer.class, 8080);
+            BrowserHomePageOpener.open("http://localhost:" + port);
+        }
+    }
+}

--- a/src/main/java/ru/investbook/BrowserHomePageOpener.java
+++ b/src/main/java/ru/investbook/BrowserHomePageOpener.java
@@ -29,7 +29,7 @@ public class BrowserHomePageOpener {
 
     static void open(String url) {
         Logger log = LoggerFactory.getLogger(BrowserHomePageOpener.class);
-        log.info("Opening browser with home page \"{}\"", url);
+        log.info("Opening browser with home page \"{}\" ...", url);
         String os = System.getProperty("os.name").toLowerCase();
         Runtime rt = Runtime.getRuntime();
         try {
@@ -53,6 +53,7 @@ public class BrowserHomePageOpener {
                 }
                 rt.exec(new String[]{"sh", "-c", cmd.toString()});
             }
+            log.info("Home page \"{}\" opening try finished successfully", url);
         } catch (Exception e) {
             log.info("Can't open home page \"{}\" with browser", url, e);
         }

--- a/src/main/java/ru/investbook/InvestbookApplication.java
+++ b/src/main/java/ru/investbook/InvestbookApplication.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.context.ServletWebServerInitializedEvent;
+import org.springframework.context.ApplicationContextException;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -33,7 +34,14 @@ public class InvestbookApplication {
     private final PortfolioProperties properties;
 
     public static void main(String[] args) {
-        SpringApplication.run(InvestbookApplication.class, args);
+        try {
+            SpringApplication app = new SpringApplication(InvestbookApplication.class);
+            app.addListeners(new ApplicationFailedRunListener());
+            app.run(args);
+        } catch (ApplicationContextException e) {
+            // gh-81 do not show "Failed to launch JVM"
+            System.exit(0);
+        }
     }
 
     @EventListener


### PR DESCRIPTION
При повторном запуске открывать домашнюю страницу приложения и не отображать ошибку "Failed to launch JVM".