### PR TITLE
ВТБ. Учесть вариацию при отображении выплат

### DIFF
--- a/src/main/java/ru/investbook/parser/vtb/VtbCashFlowTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbCashFlowTable.java
@@ -51,6 +51,7 @@ public class VtbCashFlowTable extends AbstractReportTable<EventCashFlow> {
             case "зачисление денежных средств" ->
                     description.contains("погаш. номин.ст-ти обл") ? null : CashFlowType.CASH;
             case "списание денежных средств" -> CashFlowType.CASH;
+            case "перевод денежных средств" -> CashFlowType.CASH; // перевод ДС на другой субсчет
             case "ндфл" -> CashFlowType.TAX;
             default -> null;
         };

--- a/src/main/java/ru/investbook/parser/vtb/VtbCashFlowTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbCashFlowTable.java
@@ -47,9 +47,13 @@ public class VtbCashFlowTable extends AbstractReportTable<EventCashFlow> {
                 .toLowerCase()
                 .trim();
         String description = table.getStringCellValueOrDefault(row, DESCRIPTION, "");
+        String lowercaseDescription = description.toLowerCase();
         CashFlowType type = switch (operation) {
-            case "зачисление денежных средств" ->
-                    description.contains("погаш. номин.ст-ти обл") ? null : CashFlowType.CASH;
+            case "зачисление денежных средств" -> lowercaseDescription.contains("погаш. номин.ст-ти обл") ||
+                    lowercaseDescription.contains("част.погаш") || lowercaseDescription.contains("частичное досроч") ||
+                    lowercaseDescription.contains("куп. дох. по обл") ||
+                    lowercaseDescription.contains("дивиденды") // предположение
+                    ? null : CashFlowType.CASH;
             case "списание денежных средств" -> CashFlowType.CASH;
             case "перевод денежных средств" -> CashFlowType.CASH; // перевод ДС на другой субсчет
             case "ндфл" -> CashFlowType.TAX;

--- a/src/main/java/ru/investbook/parser/vtb/VtbDividendTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbDividendTable.java
@@ -52,10 +52,11 @@ public class VtbDividendTable extends AbstractReportTable<EventCashFlow> {
     protected Collection<EventCashFlow> getRow(Table table, TableRow row) {
         String operation = String.valueOf(table.getStringCellValueOrDefault(row, OPERATION, ""))
                 .trim();
-        if (!operation.equalsIgnoreCase("Дивиденды")) {
+        String description = table.getStringCellValue(row, DESCRIPTION);
+        if (!operation.equalsIgnoreCase("Дивиденды") &&
+                !description.toLowerCase().contains("дивиденды")) { // предположение
             return Collections.emptyList();
         }
-        String description = table.getStringCellValue(row, DESCRIPTION);
 
         Collection<EventCashFlow> data = new ArrayList<>();
         BigDecimal tax = getTax(description.toLowerCase());

--- a/src/main/java/ru/investbook/parser/vtb/VtbPortfolioPropertyTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbPortfolioPropertyTable.java
@@ -73,7 +73,7 @@ public class VtbPortfolioPropertyTable extends InitializableReportTable<Portfoli
                     .value(getReport().getReportPage().getNextColumnValue(rowHeader).toString())
                     .build());
         } catch (Exception e) {
-            log.info("Не удалось распарсить свойство '{}' из {}", rowHeader, getReport().getPath());
+            log.debug("Не удалось распарсить свойство '{}' из {}", rowHeader, getReport().getPath());
             return emptyList();
         }
     }


### PR DESCRIPTION
События выплаты купонов могут отображаться в отчете 2 способами: как "купонный доход" и как "зачисления денежных средств". Аналогично события погашения и амортизация облигаций. Предполагаю, хотя и нет примера отчета, что и выплата дивидендов может отображаться в 2-х вариантах. Эти вариации учтены.

Добавлен парсинг события перевода ДС между субсчетами.