### PR TITLE
Исправить ошибку при открытии xls отчета

### DIFF
--- a/src/main/java/ru/investbook/view/excel/ExcelChartPlotHelper.java
+++ b/src/main/java/ru/investbook/view/excel/ExcelChartPlotHelper.java
@@ -20,7 +20,9 @@ package ru.investbook.view.excel;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.ClientAnchor;
+import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xddf.usermodel.PresetColor;
 import org.apache.poi.xddf.usermodel.XDDFColor;
 import org.apache.poi.xddf.usermodel.XDDFLineProperties;
@@ -134,5 +136,17 @@ public class ExcelChartPlotHelper {
                 .getScatterChartArray(0)
                 .addNewVaryColors()
                 .setVal(false);
+    }
+
+    static CellRangeAddress nonEmptyCellRangeAddress(Sheet sheet, int firstRow, int lastRow, int firstCol, int lastCol) {
+        for (int i = firstRow; i <= lastRow; i++) {
+            Row row = sheet.getRow(i);
+            for (int j = firstCol; j <= lastCol; j++) {
+                if (row.getCell(j) != null) {
+                    return new CellRangeAddress(firstRow, lastRow, firstCol, lastCol);
+                }
+            }
+        }
+        throw new IllegalArgumentException("No value in cell range");
     }
 }

--- a/src/main/java/ru/investbook/view/excel/PortfolioAnalysisExcelTableView.java
+++ b/src/main/java/ru/investbook/view/excel/PortfolioAnalysisExcelTableView.java
@@ -24,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xddf.usermodel.chart.XDDFChartData;
 import org.apache.poi.xddf.usermodel.chart.XDDFDataSource;
 import org.apache.poi.xddf.usermodel.chart.XDDFDataSourcesFactory;
@@ -129,15 +128,15 @@ public class PortfolioAnalysisExcelTableView extends ExcelTableView {
         int rowCount = sheet.getLastRowNum();
         XSSFSheet _sheet = (XSSFSheet) sheet;
 
+        XDDFDataSource<String> date = XDDFDataSourcesFactory.fromStringCellRange(_sheet,
+                nonEmptyCellRangeAddress(sheet,2, rowCount, DATE.ordinal(), DATE.ordinal()));
+        XDDFNumericalDataSource<Double> assetsUsd = XDDFDataSourcesFactory.fromNumericCellRange(_sheet,
+                nonEmptyCellRangeAddress(sheet,2, rowCount, ASSETS_USD.ordinal(), ASSETS_USD.ordinal()));
+        XDDFNumericalDataSource<Double> investmentUsd = XDDFDataSourcesFactory.fromNumericCellRange(_sheet,
+                nonEmptyCellRangeAddress(sheet,2, rowCount, TOTAL_INVESTMENT_USD.ordinal(), TOTAL_INVESTMENT_USD.ordinal()));
+
         XSSFChart chart = createChart(_sheet, name, CURRENCY_NAME.ordinal(), 6, 8, 18);
         XDDFChartData chartData = createScatterChartData(chart);
-
-        XDDFDataSource<String> date = XDDFDataSourcesFactory.fromStringCellRange(_sheet,
-                new CellRangeAddress(2, rowCount, DATE.ordinal(), DATE.ordinal()));
-        XDDFNumericalDataSource<Double> assetsUsd = XDDFDataSourcesFactory.fromNumericCellRange(_sheet,
-                new CellRangeAddress(2, rowCount, ASSETS_USD.ordinal(), ASSETS_USD.ordinal()));
-        XDDFNumericalDataSource<Double> investmentUsd = XDDFDataSourcesFactory.fromNumericCellRange(_sheet,
-                new CellRangeAddress(2, rowCount, TOTAL_INVESTMENT_USD.ordinal(), TOTAL_INVESTMENT_USD.ordinal()));
 
         XDDFChartData.Series assetsGraph = chartData.addSeries(date, assetsUsd);
         assetsGraph.setTitle("Активы", null);
@@ -152,15 +151,15 @@ public class PortfolioAnalysisExcelTableView extends ExcelTableView {
         int rowCount = sheet.getLastRowNum();
         XSSFSheet _sheet = (XSSFSheet) sheet;
 
+        XDDFDataSource<String> date = XDDFDataSourcesFactory.fromStringCellRange(_sheet,
+                nonEmptyCellRangeAddress(sheet,2, rowCount, DATE.ordinal(), DATE.ordinal()));
+        XDDFNumericalDataSource<Double> assetsGrowth = XDDFDataSourcesFactory.fromNumericCellRange(_sheet,
+                nonEmptyCellRangeAddress(sheet,2, rowCount, ASSETS_GROWTH.ordinal(), ASSETS_GROWTH.ordinal()));
+        XDDFNumericalDataSource<Double> sp500Growth = XDDFDataSourcesFactory.fromNumericCellRange(_sheet,
+                nonEmptyCellRangeAddress(sheet,2, rowCount, SP500_GROWTH.ordinal(), SP500_GROWTH.ordinal()));
+
         XSSFChart chart = createChart(_sheet, name, CURRENCY_NAME.ordinal(), 24, 8, 18);
         XDDFChartData chartData = createScatterChartData(chart);
-
-        XDDFDataSource<String> date = XDDFDataSourcesFactory.fromStringCellRange(_sheet,
-                new CellRangeAddress(2, rowCount, DATE.ordinal(), DATE.ordinal()));
-        XDDFNumericalDataSource<Double> assetsGrowth = XDDFDataSourcesFactory.fromNumericCellRange(_sheet,
-                new CellRangeAddress(2, rowCount, ASSETS_GROWTH.ordinal(), ASSETS_GROWTH.ordinal()));
-        XDDFNumericalDataSource<Double> sp500Growth = XDDFDataSourcesFactory.fromNumericCellRange(_sheet,
-                new CellRangeAddress(2, rowCount, SP500_GROWTH.ordinal(), SP500_GROWTH.ordinal()));
 
         XDDFChartData.Series assetsGrowthGraph = chartData.addSeries(date, assetsGrowth);
         assetsGrowthGraph.setTitle("Активы", null);
@@ -175,13 +174,13 @@ public class PortfolioAnalysisExcelTableView extends ExcelTableView {
         int rowCount = sheet.getLastRowNum();
         XSSFSheet _sheet = (XSSFSheet) sheet;
 
+        XDDFDataSource<String> date = XDDFDataSourcesFactory.fromStringCellRange(_sheet,
+                nonEmptyCellRangeAddress(sheet,2, rowCount, DATE.ordinal(), DATE.ordinal()));
+        XDDFNumericalDataSource<Double> cashBalance = XDDFDataSourcesFactory.fromNumericCellRange(_sheet,
+                nonEmptyCellRangeAddress(sheet,2, rowCount, TOTAL_CASH_USD.ordinal(), TOTAL_CASH_USD.ordinal()));
+
         XSSFChart chart = createChart(_sheet, name, CURRENCY_NAME.ordinal(), 42, 8, 18);
         XDDFChartData chartData = createScatterChartData(chart);
-
-        XDDFDataSource<String> date = XDDFDataSourcesFactory.fromStringCellRange(_sheet,
-                new CellRangeAddress(2, rowCount, DATE.ordinal(), DATE.ordinal()));
-        XDDFNumericalDataSource<Double> cashBalance = XDDFDataSourcesFactory.fromNumericCellRange(_sheet,
-                new CellRangeAddress(2, rowCount, TOTAL_CASH_USD.ordinal(), TOTAL_CASH_USD.ordinal()));
 
         chartData.addSeries(date, cashBalance);
         disableScatterVaryColors(chart);

--- a/src/main/java/ru/investbook/view/excel/PortfolioStatusExcelTableView.java
+++ b/src/main/java/ru/investbook/view/excel/PortfolioStatusExcelTableView.java
@@ -25,7 +25,6 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xddf.usermodel.chart.XDDFChartData;
 import org.apache.poi.xddf.usermodel.chart.XDDFDataSource;
 import org.apache.poi.xddf.usermodel.chart.XDDFDataSourcesFactory;
@@ -201,13 +200,14 @@ public class PortfolioStatusExcelTableView extends ExcelTableView {
 
     private static void addPieChart(String name, XSSFSheet sheet) {
         int rowCount = sheet.getLastRowNum();
-        XSSFChart chart = createChart(sheet, name, 0, rowCount + 2, PROPORTION.ordinal() + 1, 36);
-        XDDFChartData data = createPieChartData(chart);
 
         XDDFDataSource<String> securities = XDDFDataSourcesFactory.fromStringCellRange(sheet,
-                new CellRangeAddress(2, rowCount, SECURITY.ordinal(), SECURITY.ordinal()));
+                nonEmptyCellRangeAddress(sheet,2, rowCount, SECURITY.ordinal(), SECURITY.ordinal()));
         XDDFNumericalDataSource<Double> proportions = XDDFDataSourcesFactory.fromNumericCellRange(sheet,
-                new CellRangeAddress(2, rowCount, PROPORTION.ordinal(), PROPORTION.ordinal()));
+                nonEmptyCellRangeAddress(sheet,2, rowCount, PROPORTION.ordinal(), PROPORTION.ordinal()));
+
+        XSSFChart chart = createChart(sheet, name, 0, rowCount + 2, PROPORTION.ordinal() + 1, 36);
+        XDDFChartData data = createPieChartData(chart);
 
         data.addSeries(securities, proportions);
         chart.plot(data);


### PR DESCRIPTION
Если в составленном отчете имеются пустые графици, то Excel сообщает об ошибке.
![2021-03-12_23-50-22](https://user-images.githubusercontent.com/11336712/110997542-9c8ccd00-838e-11eb-9692-08d4ce5df5ac.png)
Не выводить в отчет пустые графики, чтобы ошибка не появлялась.