### PR TITLE
Не падать при сборке отчета при отсутствии записи о пукупке бумаги

### DIFF
--- a/src/main/java/ru/investbook/report/PaidInterest.java
+++ b/src/main/java/ru/investbook/report/PaidInterest.java
@@ -89,4 +89,22 @@ public class PaidInterest {
                 .filter(position -> position.wasOpenedAtTheInstant(instant))
                 .collect(Collectors.toCollection(LinkedList::new));
     }
+
+    /**
+     * If dividend, coupon or amortization record is exists, but no open transaction,
+     * {@link PaidInterestFactory} creates fictitious open transaction.
+     * @return true is if checking transaction is fictitious
+     */
+    public static boolean isFictitiousPosition(Position position) {
+        return position.wasOpenedAtTheInstant(fictitiousPositionInstantPlus1NonoSec);
+    }
+
+    /**
+     * If dividend, coupon or amortization record is exists, but not open transaction,
+     * {@link PaidInterestFactory} creates fictitious open transaction.
+     * @return true is if checking transaction is fictitious
+     */
+    public static boolean isFictitiousPositionTransaction(Transaction transaction) {
+        return transaction.getId() == null;
+    }
 }

--- a/src/main/java/ru/investbook/report/excel/StockMarketProfitExcelTableFactory.java
+++ b/src/main/java/ru/investbook/report/excel/StockMarketProfitExcelTableFactory.java
@@ -125,7 +125,9 @@ public class StockMarketProfitExcelTableFactory implements TableFactory {
                                                                String toCurrency) {
         Table rows = new Table();
         for (T position : positions) {
-            String openTransactionCurrency = getTransactionCurrency(position.getOpenTransaction());
+            String openTransactionCurrency = PaidInterest.isFictitiousPosition(position) ?
+                    toCurrency :
+                    getTransactionCurrency(position.getOpenTransaction());
             if (openTransactionCurrency.equalsIgnoreCase(toCurrency)) {
                 Table.Record record = profitBuilder.apply(position, toCurrency);
                 record.putAll(getPaidInterestProfit(position, paidInterest, toCurrency));
@@ -206,7 +208,7 @@ public class StockMarketProfitExcelTableFactory implements TableFactory {
     }
 
     private String getTransactionCashFlow(Transaction transaction, CashFlowType type, double multiplier, String toCurrency) {
-        if (transaction.getId() == null) {
+        if (PaidInterest.isFictitiousPositionTransaction(transaction)) {
             return null;
         }
         return transactionCashFlowRepository


### PR DESCRIPTION
Не падать при сборке отчета при отсутствии записи о пукупке бумаги и аличии записи о дивиденде, купоне, амортизации или налоге по указанным событиям.
Такое состояние в отчете возможно при ошибке ввода количества бумаг, по которым была выплата.
Relates #245 