### PR TITLE
Исключить LazyInitializationException и излишнее кеширование выплат

### DIFF
--- a/src/main/java/ru/investbook/report/PaidInterestFactory.java
+++ b/src/main/java/ru/investbook/report/PaidInterestFactory.java
@@ -25,6 +25,7 @@ import org.spacious_team.broker.pojo.Portfolio;
 import org.spacious_team.broker.pojo.Security;
 import org.spacious_team.broker.pojo.SecurityEventCashFlow;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 import ru.investbook.converter.SecurityEventCashFlowConverter;
 import ru.investbook.entity.SecurityEventCashFlowEntity;
@@ -54,6 +55,7 @@ public class PaidInterestFactory {
     private final SecurityEventCashFlowRepository securityEventCashFlowRepository;
     private final SecurityEventCashFlowConverter securityEventCashFlowConverter;
 
+    @Transactional
     public PaidInterest get(Portfolio portfolio, Security security, ViewFilter filter) {
         ViewFilter filterTillToDate = filter.toBuilder()
                 .fromDate(ViewFilter.defaultFromDate) // the entire history of positions from the first transaction is required

--- a/src/main/java/ru/investbook/report/excel/StockMarketProfitExcelTableFactory.java
+++ b/src/main/java/ru/investbook/report/excel/StockMarketProfitExcelTableFactory.java
@@ -49,8 +49,6 @@ import java.math.RoundingMode;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -63,8 +61,6 @@ import static ru.investbook.report.excel.StockMarketProfitExcelTableHeader.*;
 @RequiredArgsConstructor
 public class StockMarketProfitExcelTableFactory implements TableFactory {
     private static final String TAX_LIABILITY_FORMULA = getTaxLiabilityFormula();
-    // isin -> security price currency
-    private final Map<String, String> securityCurrencies = new ConcurrentHashMap<>();
     private final TransactionRepository transactionRepository;
     private final SecurityRepository securityRepository;
     private final TransactionCashFlowRepository transactionCashFlowRepository;


### PR DESCRIPTION
- События по дивидендам и купонам могут добавлсять без изменения количества сделок. Исключить избыточное кеширование, чтобы после загрузки новых отчетов брокера, информация о дивидендах обновлялас.
- Исключить ошибку LazyInitializationException
Relases #245