### PR TITLE
Обновить table-wrapper-api

### DIFF
--- a/src/main/java/ru/investbook/parser/TableFactoryRegistryService.java
+++ b/src/main/java/ru/investbook/parser/TableFactoryRegistryService.java
@@ -19,8 +19,8 @@
 package ru.investbook.parser;
 
 import lombok.extern.slf4j.Slf4j;
-import org.spacious_team.broker.report_parser.api.TableFactoryRegistry;
 import org.spacious_team.table_wrapper.api.TableFactory;
+import org.spacious_team.table_wrapper.api.TableFactoryRegistry;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.core.type.filter.AssignableTypeFilter;

--- a/src/main/java/ru/investbook/parser/psb/CashFlowTable.java
+++ b/src/main/java/ru/investbook/parser/psb/CashFlowTable.java
@@ -23,7 +23,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.spacious_team.broker.pojo.CashFlowType;
 import org.spacious_team.broker.pojo.EventCashFlow;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
@@ -47,8 +46,8 @@ public class CashFlowTable extends AbstractReportTable<EventCashFlow> {
     }
 
     @Override
-    protected Collection<EventCashFlow> getRow(Table table, TableRow row) {
-        String action = table.getStringCellValue(row, OPERATION);
+    protected Collection<EventCashFlow> getRow(TableRow row) {
+        String action = row.getStringCellValue(OPERATION);
         action = String.valueOf(action).toLowerCase().trim();
         CashFlowType type = CashFlowType.CASH;
         boolean isPositive;
@@ -66,17 +65,17 @@ public class CashFlowTable extends AbstractReportTable<EventCashFlow> {
             default:
                 return emptyList();
         }
-        if (type == CashFlowType.CASH && !table.getStringCellValue(row, DESCRIPTION).isEmpty()) {
+        if (type == CashFlowType.CASH && !row.getStringCellValue(DESCRIPTION).isEmpty()) {
             return emptyList(); // cash in/out records has no description
         }
-        String description = table.getStringCellValueOrDefault(row, DESCRIPTION, null);
+        String description = row.getStringCellValueOrDefault(DESCRIPTION, null);
         return singletonList(EventCashFlow.builder()
                 .portfolio(getReport().getPortfolio())
                 .eventType(type)
-                .timestamp(convertToInstant(table.getStringCellValue(row, DATE)))
-                .value(table.getCurrencyCellValue(row, VALUE)
+                .timestamp(convertToInstant(row.getStringCellValue(DATE)))
+                .value(row.getBigDecimalCellValue(VALUE)
                         .multiply(BigDecimal.valueOf(isPositive ? 1 : -1)))
-                .currency(table.getStringCellValue(row, CURRENCY))
+                .currency(row.getStringCellValue(CURRENCY))
                 .description(StringUtils.hasLength(description) ? description : null)
                 .build());
     }

--- a/src/main/java/ru/investbook/parser/psb/CashTable.java
+++ b/src/main/java/ru/investbook/parser/psb/CashTable.java
@@ -22,7 +22,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
 import org.spacious_team.broker.report_parser.api.PortfolioCash;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
@@ -46,13 +45,13 @@ public class CashTable extends AbstractReportTable<PortfolioCash> {
     }
 
     @Override
-    protected Collection<PortfolioCash> getRow(Table table, TableRow row) {
+    protected Collection<PortfolioCash> getRow(TableRow row) {
         return row.rowContains(INVALID_TEXT) ?
                 emptyList() :
                 singletonList(PortfolioCash.builder()
-                        .section(table.getStringCellValue(row, SECTION))
-                        .value(table.getCurrencyCellValue(row, VALUE))
-                        .currency(table.getStringCellValue(row, CURRENCY))
+                        .section(row.getStringCellValue(SECTION))
+                        .value(row.getBigDecimalCellValue(VALUE))
+                        .currency(row.getStringCellValue(CURRENCY))
                         .build());
     }
 

--- a/src/main/java/ru/investbook/parser/psb/CouponAmortizationRedemptionTable.java
+++ b/src/main/java/ru/investbook/parser/psb/CouponAmortizationRedemptionTable.java
@@ -23,7 +23,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.spacious_team.broker.pojo.CashFlowType;
 import org.spacious_team.broker.pojo.SecurityEventCashFlow;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
@@ -47,9 +46,9 @@ public class CouponAmortizationRedemptionTable extends AbstractReportTable<Secur
     }
 
     @Override
-    protected Collection<SecurityEventCashFlow> getRow(Table table, TableRow row) {
+    protected Collection<SecurityEventCashFlow> getRow(TableRow row) {
         CashFlowType event;
-        String action = table.getStringCellValue(row, TYPE);
+        String action = row.getStringCellValue(TYPE);
         if (action.equalsIgnoreCase("Погашение купона")) {
             event = CashFlowType.COUPON;
         } else if (action.equalsIgnoreCase("Амортизация")) {
@@ -61,18 +60,18 @@ public class CouponAmortizationRedemptionTable extends AbstractReportTable<Secur
         }
 
         BigDecimal value = ((event == CashFlowType.COUPON) ?
-                table.getCurrencyCellValue(row, COUPON) :
-                table.getCurrencyCellValue(row, VALUE));
-        BigDecimal tax = table.getCurrencyCellValue(row, TAX).negate();
+                row.getBigDecimalCellValue(COUPON) :
+                row.getBigDecimalCellValue(VALUE));
+        BigDecimal tax = row.getBigDecimalCellValue(TAX).negate();
 
         SecurityEventCashFlow.SecurityEventCashFlowBuilder builder = SecurityEventCashFlow.builder()
-                .security(table.getStringCellValue(row, ISIN))
+                .security(row.getStringCellValue(ISIN))
                 .portfolio(getReport().getPortfolio())
-                .count(table.getIntCellValue(row, COUNT))
+                .count(row.getIntCellValue(COUNT))
                 .eventType(event)
-                .timestamp(convertToInstant(table.getStringCellValue(row, DATE)))
+                .timestamp(convertToInstant(row.getStringCellValue(DATE)))
                 .value(value)
-                .currency(table.getStringCellValue(row, CURRENCY));
+                .currency(row.getStringCellValue(CURRENCY));
         Collection<SecurityEventCashFlow> data = new ArrayList<>();
         data.add(builder.build());
         if (tax.abs().compareTo(minValue) >= 0) {

--- a/src/main/java/ru/investbook/parser/psb/DerivativeQuoteTable.java
+++ b/src/main/java/ru/investbook/parser/psb/DerivativeQuoteTable.java
@@ -20,7 +20,6 @@ package ru.investbook.parser.psb;
 
 import org.spacious_team.broker.pojo.SecurityQuote;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableRow;
 
 import java.math.BigDecimal;
@@ -41,17 +40,17 @@ public class DerivativeQuoteTable extends AbstractReportTable<SecurityQuote> {
     }
 
     @Override
-    protected Collection<SecurityQuote> getRow(Table table, TableRow row) {
-        BigDecimal price = table.getCurrencyCellValue(row, PRICE);
-        BigDecimal tickValue = table.getCurrencyCellValue(row, PRICE_TICK_VALUE);
+    protected Collection<SecurityQuote> getRow(TableRow row) {
+        BigDecimal price = row.getBigDecimalCellValue(PRICE);
+        BigDecimal tickValue = row.getBigDecimalCellValue(PRICE_TICK_VALUE);
         if (price.compareTo(minValue) < 0 || tickValue.compareTo(minValue) < 0) {
             return emptyList();
         }
-        BigDecimal tick = table.getCurrencyCellValue(row, PRICE_TICK);
+        BigDecimal tick = row.getBigDecimalCellValue(PRICE_TICK);
         BigDecimal quote = price.multiply(tick)
                 .divide(tickValue, 2, RoundingMode.HALF_UP);
         return Collections.singletonList(SecurityQuote.builder()
-                .security(table.getStringCellValue(row, CONTRACT))
+                .security(row.getStringCellValue(CONTRACT))
                 .timestamp(getReport().getReportEndDateTime())
                 .quote(quote)
                 .price(price)

--- a/src/main/java/ru/investbook/parser/psb/DerivativeTransactionTable.java
+++ b/src/main/java/ru/investbook/parser/psb/DerivativeTransactionTable.java
@@ -53,20 +53,20 @@ public class DerivativeTransactionTable extends AbstractReportTable<DerivativeTr
     }
 
     @Override
-    protected Collection<DerivativeTransaction> getRow(Table table, TableRow row) {
-        boolean isBuy = table.getStringCellValue(row, DIRECTION).equalsIgnoreCase("покупка");
-        int count = table.getIntCellValue(row, COUNT);
-        String type = table.getStringCellValue(row, TYPE).toLowerCase();
+    protected Collection<DerivativeTransaction> getRow(TableRow row) {
+        boolean isBuy = row.getStringCellValue(DIRECTION).equalsIgnoreCase("покупка");
+        int count = row.getIntCellValue(COUNT);
+        String type = row.getStringCellValue(TYPE).toLowerCase();
         BigDecimal value;
         BigDecimal valueInPoints;
         switch (type) {
             case "опцион" -> {
-                value = table.getCurrencyCellValue(row, OPTION_PRICE).multiply(BigDecimal.valueOf(count));
-                valueInPoints = table.getCurrencyCellValue(row, OPTION_QUOTE).multiply(BigDecimal.valueOf(count));
+                value = row.getBigDecimalCellValue(OPTION_PRICE).multiply(BigDecimal.valueOf(count));
+                valueInPoints = row.getBigDecimalCellValue(OPTION_QUOTE).multiply(BigDecimal.valueOf(count));
             }
             case "фьючерс" -> {
-                value = table.getCurrencyCellValue(row, VALUE);
-                valueInPoints = table.getCurrencyCellValue(row, QUOTE).multiply(BigDecimal.valueOf(count));
+                value = row.getBigDecimalCellValue(VALUE);
+                valueInPoints = row.getBigDecimalCellValue(QUOTE).multiply(BigDecimal.valueOf(count));
             }
             default -> throw new IllegalArgumentException("Не известный контракт " + type);
         }
@@ -74,14 +74,14 @@ public class DerivativeTransactionTable extends AbstractReportTable<DerivativeTr
             value = value.negate();
             valueInPoints = valueInPoints.negate();
         }
-        BigDecimal commission = table.getCurrencyCellValue(row, MARKET_COMMISSION)
-                .add(table.getCurrencyCellValue(row, BROKER_COMMISSION))
+        BigDecimal commission = row.getBigDecimalCellValue(MARKET_COMMISSION)
+                .add(row.getBigDecimalCellValue(BROKER_COMMISSION))
                 .negate();
         return Collections.singleton(DerivativeTransaction.builder()
-                .timestamp(convertToInstant(table.getStringCellValue(row, DATE_TIME)))
-                .transactionId(String.valueOf(table.getLongCellValue(row, TRANSACTION))) // double numbers
+                .timestamp(convertToInstant(row.getStringCellValue(DATE_TIME)))
+                .transactionId(String.valueOf(row.getLongCellValue(TRANSACTION))) // double numbers
                 .portfolio(getReport().getPortfolio())
-                .security(table.getStringCellValue(row, CONTRACT))
+                .security(row.getStringCellValue(CONTRACT))
                 .count((isBuy ? 1 : -1) * count)
                 .valueInPoints(valueInPoints)
                 .value(value)

--- a/src/main/java/ru/investbook/parser/psb/DerivativesTable.java
+++ b/src/main/java/ru/investbook/parser/psb/DerivativesTable.java
@@ -20,7 +20,6 @@ package ru.investbook.parser.psb;
 
 import org.spacious_team.broker.pojo.Security;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableRow;
 
 import java.util.Collection;
@@ -36,9 +35,9 @@ public class DerivativesTable extends AbstractReportTable<Security> {
     }
 
     @Override
-    protected Collection<Security> getRow(Table table, TableRow row) {
+    protected Collection<Security> getRow(TableRow row) {
         return Collections.singletonList(Security.builder()
-                .id(table.getStringCellValue(row, CONTRACT))
+                .id(row.getStringCellValue(CONTRACT))
                 .build());
     }
 }

--- a/src/main/java/ru/investbook/parser/psb/DividendTable.java
+++ b/src/main/java/ru/investbook/parser/psb/DividendTable.java
@@ -23,7 +23,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.spacious_team.broker.pojo.CashFlowType;
 import org.spacious_team.broker.pojo.SecurityEventCashFlow;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
@@ -45,18 +44,18 @@ public class DividendTable extends AbstractReportTable<SecurityEventCashFlow> {
     }
 
     @Override
-    protected Collection<SecurityEventCashFlow> getRow(Table table, TableRow row) {
+    protected Collection<SecurityEventCashFlow> getRow(TableRow row) {
         SecurityEventCashFlow.SecurityEventCashFlowBuilder builder = SecurityEventCashFlow.builder()
-                .security(table.getStringCellValue(row, ISIN))
+                .security(row.getStringCellValue(ISIN))
                 .portfolio(getReport().getPortfolio())
-                .count(table.getIntCellValue(row, COUNT))
+                .count(row.getIntCellValue(COUNT))
                 .eventType(CashFlowType.DIVIDEND)
-                .timestamp(convertToInstant(table.getStringCellValue(row, DATE)))
-                .value(table.getCurrencyCellValue(row, VALUE))
-                .currency(table.getStringCellValue(row, CURRENCY));
+                .timestamp(convertToInstant(row.getStringCellValue(DATE)))
+                .value(row.getBigDecimalCellValue(VALUE))
+                .currency(row.getStringCellValue(CURRENCY));
         Collection<SecurityEventCashFlow> data = new ArrayList<>();
         data.add(builder.build());
-        BigDecimal tax = table.getCurrencyCellValue(row, TAX).negate();
+        BigDecimal tax = row.getBigDecimalCellValue(TAX).negate();
         if (tax.abs().compareTo(minValue) >= 0) {
             data.add(builder
                     .eventType(CashFlowType.TAX)

--- a/src/main/java/ru/investbook/parser/psb/ForeignExchangeRateTable.java
+++ b/src/main/java/ru/investbook/parser/psb/ForeignExchangeRateTable.java
@@ -57,10 +57,10 @@ public class ForeignExchangeRateTable extends InitializableReportTable<ForeignEx
                 return emptyList();
             }
             Collection<ForeignExchangeRate> rates = new ArrayList<>();
-            rates.addAll(createExchangeRateProperty(table, row, USD, CurrencyPair.USDRUB));
-            rates.addAll(createExchangeRateProperty(table, row, EUR, CurrencyPair.EURRUB));
-            rates.addAll(createExchangeRateProperty(table, row, GBP, CurrencyPair.GBPRUB));
-            rates.addAll(createExchangeRateProperty(table, row, CHF, CurrencyPair.CHFRUB));
+            rates.addAll(createExchangeRateProperty(row, USD, CurrencyPair.USDRUB));
+            rates.addAll(createExchangeRateProperty(row, EUR, CurrencyPair.EURRUB));
+            rates.addAll(createExchangeRateProperty(row, GBP, CurrencyPair.GBPRUB));
+            rates.addAll(createExchangeRateProperty(row, CHF, CurrencyPair.CHFRUB));
             return rates;
         } catch (Exception e) {
             log.info("Ошибка поиска стоимости активов или обменного курса в файле {}", getReport().getPath().getFileName(), e);
@@ -68,10 +68,10 @@ public class ForeignExchangeRateTable extends InitializableReportTable<ForeignEx
         }
     }
 
-    private Collection<ForeignExchangeRate> createExchangeRateProperty(Table table,
-                                                                     TableRow row, PortfolioPropertyTable.SummaryTableHeader currency,
-                                                                     CurrencyPair currencyPair) {
-        BigDecimal exchangeRate = table.getCurrencyCellValueOrDefault(row, currency, BigDecimal.ZERO);
+    private Collection<ForeignExchangeRate> createExchangeRateProperty(TableRow row,
+                                                                       PortfolioPropertyTable.SummaryTableHeader currency,
+                                                                       CurrencyPair currencyPair) {
+        BigDecimal exchangeRate = row.getBigDecimalCellValueOrDefault(currency, BigDecimal.ZERO);
         if (exchangeRate.compareTo(min) > 0) {
             return singletonList(ForeignExchangeRate.builder()
                     .date(LocalDate.ofInstant(getReport().getReportEndDateTime(), getReport().getReportZoneId()))

--- a/src/main/java/ru/investbook/parser/psb/PortfolioPropertyTable.java
+++ b/src/main/java/ru/investbook/parser/psb/PortfolioPropertyTable.java
@@ -25,15 +25,12 @@ import org.spacious_team.broker.pojo.PortfolioProperty;
 import org.spacious_team.broker.pojo.PortfolioPropertyType;
 import org.spacious_team.broker.report_parser.api.BrokerReport;
 import org.spacious_team.broker.report_parser.api.InitializableReportTable;
-import org.spacious_team.broker.report_parser.api.TableFactoryRegistry;
 import org.spacious_team.table_wrapper.api.ConstantPositionTableColumn;
 import org.spacious_team.table_wrapper.api.OptionalTableColumn;
-import org.spacious_team.table_wrapper.api.ReportPage;
 import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
-import org.spacious_team.table_wrapper.api.TableFactory;
 import org.spacious_team.table_wrapper.api.TableRow;
 
 import java.util.Collection;
@@ -62,9 +59,8 @@ public class PortfolioPropertyTable extends InitializableReportTable<PortfolioPr
     }
 
     public static Table getSummaryTable(BrokerReport report, String tableFooterString) {
-        ReportPage reportPage = report.getReportPage();
-        TableFactory tableFactory = TableFactoryRegistry.get(reportPage);
-        Table table = tableFactory.create(reportPage, SUMMARY_TABLE, tableFooterString, SummaryTableHeader.class);
+        Table table = report.getReportPage()
+                .create(SUMMARY_TABLE, tableFooterString, SummaryTableHeader.class);
         if (table.isEmpty()) {
             throw new IllegalArgumentException("Таблица '" + SUMMARY_TABLE + "' не найдена");
         }
@@ -80,7 +76,7 @@ public class PortfolioPropertyTable extends InitializableReportTable<PortfolioPr
             return Collections.singletonList(PortfolioProperty.builder()
                     .portfolio(getReport().getPortfolio())
                     .property(PortfolioPropertyType.TOTAL_ASSETS_RUB)
-                    .value(table.getCurrencyCellValue(row, RUB).toString())
+                    .value(row.getBigDecimalCellValue(RUB).toString())
                     .timestamp(getReport().getReportEndDateTime())
                     .build());
         } catch (Exception e) {

--- a/src/main/java/ru/investbook/parser/psb/SecuritiesTable.java
+++ b/src/main/java/ru/investbook/parser/psb/SecuritiesTable.java
@@ -22,7 +22,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.spacious_team.broker.pojo.Security;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
@@ -46,12 +45,12 @@ public class SecuritiesTable extends AbstractReportTable<Security> {
     }
 
     @Override
-    protected Collection<Security> getRow(Table table, TableRow row) {
+    protected Collection<Security> getRow(TableRow row) {
         return row.rowContains(INVALID_TEXT) ?
                 emptyList() :
                 Collections.singletonList(Security.builder()
-                        .id(table.getStringCellValue(row, ISIN))
-                        .name(table.getStringCellValue(row, NAME))
+                        .id(row.getStringCellValue(ISIN))
+                        .name(row.getStringCellValue(NAME))
                         .build());
     }
 

--- a/src/main/java/ru/investbook/parser/psb/SecurityQuoteTable.java
+++ b/src/main/java/ru/investbook/parser/psb/SecurityQuoteTable.java
@@ -20,7 +20,6 @@ package ru.investbook.parser.psb;
 
 import org.spacious_team.broker.pojo.SecurityQuote;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableRow;
 
 import java.math.BigDecimal;
@@ -41,18 +40,18 @@ public class SecurityQuoteTable extends AbstractReportTable<SecurityQuote> {
     }
 
     @Override
-    protected Collection<SecurityQuote> getRow(Table table, TableRow row) {
+    protected Collection<SecurityQuote> getRow(TableRow row) {
         if (row.rowContains(SecuritiesTable.INVALID_TEXT)) {
             return emptyList();
         }
-        int count = table.getIntCellValue(row, OUTGOING);
+        int count = row.getIntCellValue(OUTGOING);
         if (count == 0) {
             return emptyList();
         }
-        BigDecimal amount = table.getCurrencyCellValue(row, AMOUNT);
+        BigDecimal amount = row.getBigDecimalCellValue(AMOUNT);
         BigDecimal price = amount.divide(BigDecimal.valueOf(count), 4, RoundingMode.HALF_UP);
-        BigDecimal quote = table.getCurrencyCellValue(row, QUOTE);
-        BigDecimal accruedInterest = table.getCurrencyCellValue(row, ACCRUED_INTEREST)
+        BigDecimal quote = row.getBigDecimalCellValue(QUOTE);
+        BigDecimal accruedInterest = row.getBigDecimalCellValue(ACCRUED_INTEREST)
                 .divide(BigDecimal.valueOf(count), 2, RoundingMode.HALF_UP);
         if (accruedInterest.compareTo(minValue) < 0 && price.subtract(quote).abs().compareTo(minValue) < 0) {
             // акция
@@ -60,7 +59,7 @@ public class SecurityQuoteTable extends AbstractReportTable<SecurityQuote> {
             accruedInterest = null;
         }
         return Collections.singletonList(SecurityQuote.builder()
-                .security(table.getStringCellValue(row, ISIN))
+                .security(row.getStringCellValue(ISIN))
                 .timestamp(getReport().getReportEndDateTime())
                 .quote(quote)
                 .price(price)

--- a/src/main/java/ru/investbook/parser/psb/SecurityTransactionTable.java
+++ b/src/main/java/ru/investbook/parser/psb/SecurityTransactionTable.java
@@ -22,14 +22,10 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.spacious_team.broker.report_parser.api.InitializableReportTable;
 import org.spacious_team.broker.report_parser.api.SecurityTransaction;
-import org.spacious_team.broker.report_parser.api.TableFactoryRegistry;
 import org.spacious_team.table_wrapper.api.AnyOfTableColumn;
-import org.spacious_team.table_wrapper.api.ReportPage;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
-import org.spacious_team.table_wrapper.api.TableFactory;
 import org.spacious_team.table_wrapper.api.TableRow;
 
 import java.math.BigDecimal;
@@ -60,36 +56,35 @@ public class SecurityTransactionTable extends InitializableReportTable<SecurityT
     }
 
     private List<SecurityTransaction> parseTable(PsbBrokerReport report, String tableName) {
-        ReportPage reportPage = getReport().getReportPage();
-        TableFactory tableFactory = TableFactoryRegistry.get(reportPage);
-        Table table = tableFactory.create(report.getReportPage(), tableName, TABLE_END_TEXT, TransactionTableHeader.class);
-        return table.getDataCollection(report.getPath(), this::getTransaction);
+        return getReport().getReportPage()
+                .create(tableName, TABLE_END_TEXT, TransactionTableHeader.class)
+                .getDataCollection(report.getPath(), this::getTransaction);
     }
 
-    private Collection<SecurityTransaction> getTransaction(Table table, TableRow row) {
-        boolean isBuy = table.getStringCellValue(row, DIRECTION).equalsIgnoreCase("покупка");
-        BigDecimal value = table.getCurrencyCellValue(row, VALUE);
-        BigDecimal accruedInterest = table.getCurrencyCellValue(row, ACCRUED_INTEREST);
+    private Collection<SecurityTransaction> getTransaction(TableRow row) {
+        boolean isBuy = row.getStringCellValue(DIRECTION).equalsIgnoreCase("покупка");
+        BigDecimal value = row.getBigDecimalCellValue(VALUE);
+        BigDecimal accruedInterest = row.getBigDecimalCellValue(ACCRUED_INTEREST);
         if (isBuy) {
             value = value.negate();
             accruedInterest = accruedInterest.negate();
         }
-        BigDecimal commission = table.getCurrencyCellValue(row, MARKET_COMMISSION)
-                .add(table.getCurrencyCellValue(row, BROKER_COMMISSION))
-                .add(table.getCurrencyCellValue(row, CLEARING_COMMISSION))
-                .add(table.getCurrencyCellValue(row, ITS_COMMISSION))
+        BigDecimal commission = row.getBigDecimalCellValue(MARKET_COMMISSION)
+                .add(row.getBigDecimalCellValue(BROKER_COMMISSION))
+                .add(row.getBigDecimalCellValue(CLEARING_COMMISSION))
+                .add(row.getBigDecimalCellValue(ITS_COMMISSION))
                 .negate();
         return Collections.singletonList(SecurityTransaction.builder()
-                .timestamp(getReport().convertToInstant(table.getStringCellValue(row, DATE_TIME)))
-                .transactionId(String.valueOf(table.getLongCellValue(row, TRANSACTION))) // may be double numbers in future
+                .timestamp(getReport().convertToInstant(row.getStringCellValue(DATE_TIME)))
+                .transactionId(String.valueOf(row.getLongCellValue(TRANSACTION))) // may be double numbers in future
                 .portfolio(getReport().getPortfolio())
-                .security(table.getStringCellValue(row, ISIN))
-                .count((isBuy ? 1 : -1) * table.getIntCellValue(row, COUNT))
+                .security(row.getStringCellValue(ISIN))
+                .count((isBuy ? 1 : -1) * row.getIntCellValue(COUNT))
                 .value(value)
                 .accruedInterest((accruedInterest.abs().compareTo(minValue) >= 0) ? accruedInterest : BigDecimal.ZERO)
                 .commission(commission)
-                .valueCurrency(table.getStringCellValue(row, VALUE_CURRENCY).replace(" ", "").split("/")[1])
-                .commissionCurrency(table.getStringCellValue(row, COMMISSION_CURRENCY))
+                .valueCurrency(row.getStringCellValue(VALUE_CURRENCY).replace(" ", "").split("/")[1])
+                .commissionCurrency(row.getStringCellValue(COMMISSION_CURRENCY))
                 .build());
     }
 

--- a/src/main/java/ru/investbook/parser/psb/foreignmarket/ForeignExchangeCashFlowTable.java
+++ b/src/main/java/ru/investbook/parser/psb/foreignmarket/ForeignExchangeCashFlowTable.java
@@ -55,8 +55,8 @@ public class ForeignExchangeCashFlowTable extends AbstractReportTable<EventCashF
     }
 
     @Override
-    protected Collection<EventCashFlow> getRow(Table table, TableRow row) {
-        String action = table.getStringCellValue(row, OPERATION);
+    protected Collection<EventCashFlow> getRow(TableRow row) {
+        String action = row.getStringCellValue(OPERATION);
         action = String.valueOf(action).toLowerCase().trim();
         boolean isPositive;
         switch (action) {
@@ -67,19 +67,19 @@ public class ForeignExchangeCashFlowTable extends AbstractReportTable<EventCashF
                 isPositive = false;
                 break;
             default:
-                log.debug("Не известный тип операции '{}' в таблице '{}'", action, table);
+                log.debug("Не известный тип операции '{}' в таблице '{}'", action, row.getTable());
                 return emptyList();
         }
         String currency;
-        BigDecimal value = table.getCurrencyCellValue(row, RUB);
+        BigDecimal value = row.getBigDecimalCellValue(RUB);
         if (value.compareTo(min) > 0) {
             currency = "RUB";
         } else {
-            value = table.getCurrencyCellValue(row, USD);
+            value = row.getBigDecimalCellValue(USD);
             if (value.compareTo(min) > 0) {
                 currency = "USD";
             } else {
-                value = table.getCurrencyCellValue(row, EUR);
+                value = row.getBigDecimalCellValue(EUR);
                 if (value.compareTo(min) > 0) {
                     currency = "EUR";
                 } else {
@@ -90,7 +90,7 @@ public class ForeignExchangeCashFlowTable extends AbstractReportTable<EventCashF
         return singletonList(EventCashFlow.builder()
                 .portfolio(getReport().getPortfolio())
                 .eventType(CashFlowType.CASH)
-                .timestamp(convertToInstant(table.getStringCellValue(row, DATE)))
+                .timestamp(convertToInstant(row.getStringCellValue(DATE)))
                 .value(value.multiply(BigDecimal.valueOf(isPositive ? 1 : -1)))
                 .currency(currency)
                 .description("Операция по валютному счету")

--- a/src/main/java/ru/investbook/parser/psb/foreignmarket/ForeignExchangeCashTable.java
+++ b/src/main/java/ru/investbook/parser/psb/foreignmarket/ForeignExchangeCashTable.java
@@ -22,10 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.spacious_team.broker.report_parser.api.BrokerReport;
 import org.spacious_team.broker.report_parser.api.InitializableReportTable;
 import org.spacious_team.broker.report_parser.api.PortfolioCash;
-import org.spacious_team.broker.report_parser.api.TableFactoryRegistry;
-import org.spacious_team.table_wrapper.api.ReportPage;
 import org.spacious_team.table_wrapper.api.Table;
-import org.spacious_team.table_wrapper.api.TableFactory;
 import org.spacious_team.table_wrapper.api.TableRow;
 import ru.investbook.parser.psb.PortfolioPropertyTable;
 
@@ -56,7 +53,7 @@ public class ForeignExchangeCashTable extends InitializableReportTable<Portfolio
         }
         Collection<PortfolioCash> cashes = new ArrayList<>();
         for (PortfolioPropertyTable.SummaryTableHeader currency : CURRENCIES) {
-            BigDecimal cash = table.getCurrencyCellValueOrDefault(row, currency, null);
+            BigDecimal cash = row.getBigDecimalCellValueOrDefault(currency, null);
             if (cash != null) {
                 cashes.add(PortfolioCash.builder()
                         .section("валютный рынок")
@@ -69,9 +66,8 @@ public class ForeignExchangeCashTable extends InitializableReportTable<Portfolio
     }
 
     private Table getSummaryTable() {
-        ReportPage reportPage = getReport().getReportPage();
-        TableFactory tableFactory = TableFactoryRegistry.get(reportPage);
-        Table table = tableFactory.create(reportPage, SUMMARY_TABLE, ASSETS, PortfolioPropertyTable.SummaryTableHeader.class);
+        Table table = getReport().getReportPage()
+                .create(SUMMARY_TABLE, ASSETS, PortfolioPropertyTable.SummaryTableHeader.class);
         if (table.isEmpty()) {
             throw new IllegalArgumentException("Таблица '" + SUMMARY_TABLE + "' не найдена");
         }

--- a/src/main/java/ru/investbook/parser/psb/foreignmarket/ForeignExchangePortfolioPropertyTable.java
+++ b/src/main/java/ru/investbook/parser/psb/foreignmarket/ForeignExchangePortfolioPropertyTable.java
@@ -55,15 +55,15 @@ public class ForeignExchangePortfolioPropertyTable extends PortfolioPropertyTabl
             if (assetsRow == null || exchangeRateRow == null) {
                 return emptyList();
             }
-            BigDecimal totalAssets = table.getCurrencyCellValueOrDefault(assetsRow, RUB, BigDecimal.ZERO)
-                    .add(table.getCurrencyCellValueOrDefault(assetsRow, USD, BigDecimal.ZERO)
-                            .multiply(table.getCurrencyCellValueOrDefault(exchangeRateRow, USD, BigDecimal.ZERO)))
-                    .add(table.getCurrencyCellValueOrDefault(assetsRow, EUR, BigDecimal.ZERO)
-                            .multiply(table.getCurrencyCellValueOrDefault(exchangeRateRow, EUR, BigDecimal.ZERO)))
-                    .add(table.getCurrencyCellValueOrDefault(assetsRow, GBP, BigDecimal.ZERO)
-                            .multiply(table.getCurrencyCellValueOrDefault(exchangeRateRow, GBP, BigDecimal.ZERO)))
-                    .add(table.getCurrencyCellValueOrDefault(assetsRow, CHF, BigDecimal.ZERO)
-                            .multiply(table.getCurrencyCellValueOrDefault(exchangeRateRow, CHF, BigDecimal.ZERO)));
+            BigDecimal totalAssets = assetsRow.getBigDecimalCellValueOrDefault(RUB, BigDecimal.ZERO)
+                    .add(assetsRow.getBigDecimalCellValueOrDefault(USD, BigDecimal.ZERO)
+                            .multiply(exchangeRateRow.getBigDecimalCellValueOrDefault(USD, BigDecimal.ZERO)))
+                    .add(assetsRow.getBigDecimalCellValueOrDefault(EUR, BigDecimal.ZERO)
+                            .multiply(exchangeRateRow.getBigDecimalCellValueOrDefault(EUR, BigDecimal.ZERO)))
+                    .add(assetsRow.getBigDecimalCellValueOrDefault(GBP, BigDecimal.ZERO)
+                            .multiply(exchangeRateRow.getBigDecimalCellValueOrDefault(GBP, BigDecimal.ZERO)))
+                    .add(assetsRow.getBigDecimalCellValueOrDefault(CHF, BigDecimal.ZERO)
+                            .multiply(exchangeRateRow.getBigDecimalCellValueOrDefault(CHF, BigDecimal.ZERO)));
             return Collections.singletonList(PortfolioProperty.builder()
                     .portfolio(getReport().getPortfolio())
                     .property(PortfolioPropertyType.TOTAL_ASSETS_RUB)

--- a/src/main/java/ru/investbook/parser/psb/foreignmarket/ForeignExchangeTransactionTable.java
+++ b/src/main/java/ru/investbook/parser/psb/foreignmarket/ForeignExchangeTransactionTable.java
@@ -22,7 +22,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
 import org.spacious_team.broker.report_parser.api.ForeignExchangeTransaction;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
@@ -44,26 +43,26 @@ public class ForeignExchangeTransactionTable extends AbstractReportTable<Foreign
     }
 
     @Override
-    protected Collection<ForeignExchangeTransaction> getRow(Table table, TableRow row) {
-        String dateTime = table.getStringCellValue(row, DATE_TIME); // 08.02.2019 23:37
+    protected Collection<ForeignExchangeTransaction> getRow(TableRow row) {
+        String dateTime = row.getStringCellValue(DATE_TIME); // 08.02.2019 23:37
         Instant transactionInstant = convertToInstant(dateTime);
-        String notUniqTransactionId = table.getStringCellValue(row, TRANSACTION);
+        String notUniqTransactionId = row.getStringCellValue(TRANSACTION);
         String transactionId = notUniqTransactionId + dateTime.replaceAll("[.\\s:]", "");
-        boolean isBuy = table.getStringCellValue(row, DIRECTION).trim().equalsIgnoreCase("К");
-        BigDecimal value = table.getCurrencyCellValue(row, VALUE);
+        boolean isBuy = row.getStringCellValue(DIRECTION).trim().equalsIgnoreCase("К");
+        BigDecimal value = row.getBigDecimalCellValue(VALUE);
         if (isBuy) {
             value = value.negate();
         }
-        String contract = table.getStringCellValue(row, CONTRACT);
+        String contract = row.getStringCellValue(CONTRACT);
         String quoteCurrency = contract.substring(3, 6).toUpperCase(); // extracts RUB from USDRUB_TOM
         return Collections.singletonList(ForeignExchangeTransaction.builder()
                 .timestamp(transactionInstant)
                 .transactionId(transactionId)
                 .portfolio(getReport().getPortfolio())
                 .security(contract)
-                .count((isBuy ? 1 : -1) * table.getIntCellValue(row, COUNT))
+                .count((isBuy ? 1 : -1) * row.getIntCellValue(COUNT))
                 .value(value)
-                .commission(table.getCurrencyCellValue(row, MARKET_COMMISSION).negate())
+                .commission(row.getBigDecimalCellValue(MARKET_COMMISSION).negate())
                 .valueCurrency(quoteCurrency)
                 .commissionCurrency("RUB")
                 .build());

--- a/src/main/java/ru/investbook/parser/uralsib/AssetsTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/AssetsTable.java
@@ -25,15 +25,12 @@ import org.spacious_team.broker.pojo.PortfolioProperty;
 import org.spacious_team.broker.pojo.PortfolioPropertyType;
 import org.spacious_team.broker.report_parser.api.BrokerReport;
 import org.spacious_team.broker.report_parser.api.InitializableReportTable;
-import org.spacious_team.broker.report_parser.api.TableFactoryRegistry;
 import org.spacious_team.table_wrapper.api.AnyOfTableColumn;
 import org.spacious_team.table_wrapper.api.MultiLineTableColumn;
-import org.spacious_team.table_wrapper.api.ReportPage;
 import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
-import org.spacious_team.table_wrapper.api.TableFactory;
 import org.spacious_team.table_wrapper.api.TableRow;
 
 import java.util.Collection;
@@ -61,13 +58,11 @@ public class AssetsTable extends InitializableReportTable<PortfolioProperty> {
     protected Collection<PortfolioProperty> parseTable() {
         try {
             BrokerReport report = getReport();
-            ReportPage reportPage = report.getReportPage();
-            TableFactory tableFactory = TableFactoryRegistry.get(reportPage);
-            Table table = tableFactory.createOfNoName(reportPage, ASSETS_TABLE, TABLE_FIRST_HEADER_LINE,
-                    SummaryTableHeader.class, 3);
+            Table table = report.getReportPage()
+                    .createOfNoName(ASSETS_TABLE, TABLE_FIRST_HEADER_LINE, SummaryTableHeader.class, 3);
             if (table.isEmpty()) {
-                table = tableFactory.createOfNoName(reportPage, ASSETS_TABLE, TABLE_SECOND_HEADER_LINE,
-                        SummaryTableHeader.class, 2);
+                table = report.getReportPage()
+                        .createOfNoName(ASSETS_TABLE, TABLE_SECOND_HEADER_LINE, SummaryTableHeader.class, 2);
             }
             if (table.isEmpty()) {
                 log.debug("Таблица '{}' не найдена", ASSETS_TABLE);
@@ -83,7 +78,7 @@ public class AssetsTable extends InitializableReportTable<PortfolioProperty> {
                     .portfolio(report.getPortfolio())
                     .timestamp(report.getReportEndDateTime())
                     .property(PortfolioPropertyType.TOTAL_ASSETS_RUB)
-                    .value(table.getCurrencyCellValue(row, RUB).toString())
+                    .value(row.getBigDecimalCellValue(RUB).toString())
                     .build());
         } catch (Exception e) {
             log.info("Не могу распарсить таблицу '{}' в файле {}", ASSETS_TABLE, getReport().getPath().getFileName(), e);

--- a/src/main/java/ru/investbook/parser/uralsib/CashFlowTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/CashFlowTable.java
@@ -22,7 +22,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.spacious_team.broker.pojo.CashFlowType;
 import org.spacious_team.broker.pojo.EventCashFlow;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableRow;
 import org.springframework.util.StringUtils;
 
@@ -46,10 +45,10 @@ public class CashFlowTable extends AbstractReportTable<EventCashFlow> {
     }
 
     @Override
-    protected Collection<EventCashFlow> getRow(Table table, TableRow row) {
-        String action = table.getStringCellValue(row, OPERATION);
+    protected Collection<EventCashFlow> getRow(TableRow row) {
+        String action = row.getStringCellValue(OPERATION);
         action = String.valueOf(action).toLowerCase().trim();
-        String description = table.getStringCellValueOrDefault(row, DESCRIPTION, "");
+        String description = row.getStringCellValueOrDefault(DESCRIPTION, "");
         CashFlowType type;
         switch (action) {
             case"ввод дс":
@@ -83,9 +82,9 @@ public class CashFlowTable extends AbstractReportTable<EventCashFlow> {
         return singletonList(EventCashFlow.builder()
                 .portfolio(getReport().getPortfolio())
                 .eventType(type)
-                .timestamp(convertToInstant(table.getStringCellValue(row, DATE)))
-                .value(table.getCurrencyCellValue(row, VALUE))
-                .currency(UralsibBrokerReport.convertToCurrency(table.getStringCellValue(row, CURRENCY)))
+                .timestamp(convertToInstant(row.getStringCellValue(DATE)))
+                .value(row.getBigDecimalCellValue(VALUE))
+                .currency(UralsibBrokerReport.convertToCurrency(row.getStringCellValue(CURRENCY)))
                 .description(StringUtils.hasLength(description) ? description : null)
                 .build());
     }

--- a/src/main/java/ru/investbook/parser/uralsib/CashTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/CashTable.java
@@ -22,7 +22,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
 import org.spacious_team.broker.report_parser.api.PortfolioCash;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
@@ -44,11 +43,11 @@ public class CashTable extends AbstractReportTable<PortfolioCash> {
     }
 
     @Override
-    protected Collection<PortfolioCash> getRow(Table table, TableRow row) {
+    protected Collection<PortfolioCash> getRow(TableRow row) {
         return singletonList(PortfolioCash.builder()
                 .section("all")
-                .value(table.getCurrencyCellValue(row, VALUE))
-                .currency(UralsibBrokerReport.convertToCurrency(table.getStringCellValue(row, CURRENCY)))
+                .value(row.getBigDecimalCellValue(VALUE))
+                .currency(UralsibBrokerReport.convertToCurrency(row.getStringCellValue(CURRENCY)))
                 .build());
     }
 

--- a/src/main/java/ru/investbook/parser/uralsib/CouponAmortizationRedemptionTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/CouponAmortizationRedemptionTable.java
@@ -51,9 +51,9 @@ public class CouponAmortizationRedemptionTable extends PaymentsTable {
         this.redemptionDates = new SecurityRedemptionTable(report).getData();
     }
 
-    protected Collection<SecurityEventCashFlow> getRow(Table table, TableRow row) {
+    protected Collection<SecurityEventCashFlow> getRow(TableRow row) {
         CashFlowType event;
-        String action = table.getStringCellValue(row, OPERATION);
+        String action = row.getStringCellValue(OPERATION);
         action = String.valueOf(action).toLowerCase().trim();
         if (action.equalsIgnoreCase("погашение купона")) {
             event = CashFlowType.COUPON;
@@ -63,9 +63,9 @@ public class CouponAmortizationRedemptionTable extends PaymentsTable {
             return emptyList();
         }
 
-        Security security = getSecurity(table, row, CashFlowType.AMORTIZATION);
+        Security security = getSecurity(row, CashFlowType.AMORTIZATION);
         if (security == null) return emptyList();
-        Instant timestamp = getReport().convertToInstant(table.getStringCellValue(row, DATE));
+        Instant timestamp = getReport().convertToInstant(row.getStringCellValue(DATE));
 
         if (event == null) {
             if (isRedemption(security.getName(), timestamp)) {
@@ -75,8 +75,8 @@ public class CouponAmortizationRedemptionTable extends PaymentsTable {
             }
         }
 
-        BigDecimal tax = getTax(table, row);
-        BigDecimal value = table.getCurrencyCellValue(row, VALUE)
+        BigDecimal tax = getTax(row);
+        BigDecimal value = row.getBigDecimalCellValue(VALUE)
                 .add(tax.abs());
         SecurityEventCashFlow.SecurityEventCashFlowBuilder builder = SecurityEventCashFlow.builder()
                 .security(security.getId())
@@ -85,7 +85,7 @@ public class CouponAmortizationRedemptionTable extends PaymentsTable {
                 .eventType(event)
                 .timestamp(timestamp)
                 .value(value)
-                .currency(UralsibBrokerReport.convertToCurrency(table.getStringCellValue(row, CURRENCY)));
+                .currency(UralsibBrokerReport.convertToCurrency(row.getStringCellValue(CURRENCY)));
         Collection<SecurityEventCashFlow> data = new ArrayList<>();
         data.add(builder.build());
 

--- a/src/main/java/ru/investbook/parser/uralsib/DerivativeCashFlowTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/DerivativeCashFlowTable.java
@@ -22,7 +22,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.spacious_team.broker.pojo.CashFlowType;
 import org.spacious_team.broker.pojo.SecurityEventCashFlow;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableRow;
 
 import java.util.Collection;
@@ -42,24 +41,24 @@ public class DerivativeCashFlowTable extends AbstractReportTable<SecurityEventCa
         super(report, PaymentsTable.TABLE_NAME, "", PaymentsTable.PaymentsTableHeader.class);
     }
 
-    protected Collection<SecurityEventCashFlow> getRow(Table table, TableRow row) {
-        String action = table.getStringCellValue(row, OPERATION);
+    protected Collection<SecurityEventCashFlow> getRow(TableRow row) {
+        String action = row.getStringCellValue(OPERATION);
         action = String.valueOf(action).toLowerCase().trim();
         if (!action.equalsIgnoreCase("вариационная маржа")) {
             return emptyList();
         }
         return singletonList(SecurityEventCashFlow.builder()
-                .timestamp(convertToInstant(table.getStringCellValue(row, DATE)))
+                .timestamp(convertToInstant(row.getStringCellValue(DATE)))
                 .portfolio(getReport().getPortfolio())
-                .value(table.getCurrencyCellValue(row, VALUE))
-                .currency(UralsibBrokerReport.convertToCurrency(table.getStringCellValue(row, CURRENCY)))
+                .value(row.getBigDecimalCellValue(VALUE))
+                .currency(UralsibBrokerReport.convertToCurrency(row.getStringCellValue(CURRENCY)))
                 .eventType(CashFlowType.DERIVATIVE_PROFIT)
-                .security(getContract(table, row))
+                .security(getContract(row))
                 .build());
     }
 
-    private String getContract(Table table, TableRow row) {
-        String description = table.getStringCellValueOrDefault(row, DESCRIPTION, "");
+    private String getContract(TableRow row) {
+        String description = row.getStringCellValueOrDefault(DESCRIPTION, "");
         Matcher matcher = contractPattern.matcher(description);
         if (matcher.find()) {
             return matcher.group(1);

--- a/src/main/java/ru/investbook/parser/uralsib/DerivativeQuoteTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/DerivativeQuoteTable.java
@@ -21,7 +21,6 @@ package ru.investbook.parser.uralsib;
 import lombok.Getter;
 import org.spacious_team.broker.pojo.SecurityQuote;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
@@ -46,13 +45,13 @@ public class DerivativeQuoteTable extends AbstractReportTable<SecurityQuote> {
     }
 
     @Override
-    protected Collection<SecurityQuote> getRow(Table table, TableRow row) {
-        BigDecimal quote = table.getCurrencyCellValueOrDefault(row, QUOTE, null);
+    protected Collection<SecurityQuote> getRow(TableRow row) {
+        BigDecimal quote = row.getBigDecimalCellValueOrDefault(QUOTE, null);
         if (quote == null || quote.compareTo(minValue) < 0) {
             return emptyList();
         }
         return Collections.singletonList(SecurityQuote.builder()
-                .security(table.getStringCellValue(row, CONTRACT))
+                .security(row.getStringCellValue(CONTRACT))
                 .timestamp(getReport().getReportEndDateTime())
                 .quote(quote)
                 .build());

--- a/src/main/java/ru/investbook/parser/uralsib/DividendTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/DividendTable.java
@@ -24,7 +24,6 @@ import org.spacious_team.broker.pojo.Security;
 import org.spacious_team.broker.pojo.SecurityEventCashFlow;
 import org.spacious_team.broker.report_parser.api.ReportTable;
 import org.spacious_team.broker.report_parser.api.SecurityTransaction;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableRow;
 
 import java.math.BigDecimal;
@@ -47,21 +46,21 @@ public class DividendTable extends PaymentsTable {
     }
 
     @Override
-    protected Collection<SecurityEventCashFlow> getRow(Table table, TableRow row) {
-        String action = table.getStringCellValue(row, OPERATION);
+    protected Collection<SecurityEventCashFlow> getRow(TableRow row) {
+        String action = row.getStringCellValue(OPERATION);
         action = String.valueOf(action).toLowerCase().trim();
-        String description = table.getStringCellValueOrDefault(row, DESCRIPTION, "");
+        String description = row.getStringCellValueOrDefault(DESCRIPTION, "");
         description = String.valueOf(description).toLowerCase();
         if (!action.equalsIgnoreCase(DIVIDEND_ACTION) || !description.contains("дивиденд")) {
             return emptyList();
         }
 
-        Security security = getSecurity(table, row, CashFlowType.DIVIDEND);
+        Security security = getSecurity(row, CashFlowType.DIVIDEND);
         if (security == null) return emptyList();
-        Instant timestamp = getReport().convertToInstant(table.getStringCellValue(row, DATE));
+        Instant timestamp = getReport().convertToInstant(row.getStringCellValue(DATE));
 
-        BigDecimal tax = getTax(table, row);
-        BigDecimal value = table.getCurrencyCellValue(row, VALUE)
+        BigDecimal tax = getTax(row);
+        BigDecimal value = row.getBigDecimalCellValue(VALUE)
                 .add(tax.abs());
         SecurityEventCashFlow.SecurityEventCashFlowBuilder builder = SecurityEventCashFlow.builder()
                 .security(security.getId())
@@ -70,7 +69,7 @@ public class DividendTable extends PaymentsTable {
                 .eventType(CashFlowType.DIVIDEND)
                 .timestamp(timestamp)
                 .value(value)
-                .currency(UralsibBrokerReport.convertToCurrency(table.getStringCellValue(row, CURRENCY)));
+                .currency(UralsibBrokerReport.convertToCurrency(row.getStringCellValue(CURRENCY)));
 
         Collection<SecurityEventCashFlow> data = new ArrayList<>();
         data.add(builder.build());

--- a/src/main/java/ru/investbook/parser/uralsib/ForeignExchangeRateTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/ForeignExchangeRateTable.java
@@ -57,7 +57,7 @@ public class ForeignExchangeRateTable extends InitializableReportTable<ForeignEx
             }
             List<ForeignExchangeRate> exchangeRates = new ArrayList<>();
             TableCell cell = report.getReportPage().getRow(address.getRow() + 1).getCell(0);
-            String text = cell.getStringCellValue();
+            String text = cell.getStringValue();
             String[] words = text.split(" ");
             for (int i = 0; i < words.length; i++) {
                 try {

--- a/src/main/java/ru/investbook/parser/uralsib/ForeignExchangeTransactionTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/ForeignExchangeTransactionTable.java
@@ -22,7 +22,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
 import org.spacious_team.broker.report_parser.api.ForeignExchangeTransaction;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
@@ -46,9 +45,9 @@ public class ForeignExchangeTransactionTable extends AbstractReportTable<Foreign
     }
 
     @Override
-    protected Collection<ForeignExchangeTransaction> getRow(Table table, TableRow row) {
+    protected Collection<ForeignExchangeTransaction> getRow(TableRow row) {
         String transactionId;
-        Object cellValue = table.getCellValue(row, TRANSACTION);
+        Object cellValue = row.getCellValue(TRANSACTION);
         if (cellValue instanceof String) {
             String stringValue = cellValue.toString();
             try {
@@ -70,24 +69,24 @@ public class ForeignExchangeTransactionTable extends AbstractReportTable<Foreign
             return emptyList();
         }
 
-        boolean isBuy = table.getStringCellValue(row, DIRECTION).equalsIgnoreCase("покупка");
-        BigDecimal value = table.getCurrencyCellValue(row, VALUE);
+        boolean isBuy = row.getStringCellValue(DIRECTION).equalsIgnoreCase("покупка");
+        BigDecimal value = row.getBigDecimalCellValue(VALUE);
         if (isBuy) {
             value = value.negate();
         }
-        BigDecimal commission = table.getCurrencyCellValue(row, MARKET_COMMISSION)
-                .add(table.getCurrencyCellValue(row, BROKER_COMMISSION))
+        BigDecimal commission = row.getBigDecimalCellValue(MARKET_COMMISSION)
+                .add(row.getBigDecimalCellValue(BROKER_COMMISSION))
                 .negate();
 
         return Collections.singletonList(ForeignExchangeTransaction.builder()
-                .timestamp(getReport().convertToInstant(table.getStringCellValue(row, DATE_TIME)))
+                .timestamp(getReport().convertToInstant(row.getStringCellValue(DATE_TIME)))
                 .transactionId(transactionId)
                 .portfolio(getReport().getPortfolio())
                 .security(instrument)
-                .count((isBuy ? 1 : -1) * table.getIntCellValue(row, COUNT))
+                .count((isBuy ? 1 : -1) * row.getIntCellValue(COUNT))
                 .value(value)
                 .commission(commission)
-                .valueCurrency(UralsibBrokerReport.convertToCurrency(table.getStringCellValue(row, VALUE_CURRENCY)))
+                .valueCurrency(UralsibBrokerReport.convertToCurrency(row.getStringCellValue(VALUE_CURRENCY)))
                 .commissionCurrency("RUB")
                 .build());
     }

--- a/src/main/java/ru/investbook/parser/uralsib/PaymentsTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/PaymentsTable.java
@@ -76,26 +76,26 @@ abstract class PaymentsTable extends AbstractReportTable<SecurityEventCashFlow> 
                 this::checkEquality, this::mergeDuplicates);
     }
 
-    private Collection<SecurityEventCashFlow> getRowAndSaveDescription(Table table, TableRow row) {
+    private Collection<SecurityEventCashFlow> getRowAndSaveDescription(TableRow row) {
         // Тип операции = "Разблокировано средств ГО" имеет пустое описание, не падаем, возвращаем default
-        currentRowDescription = table.getStringCellValueOrDefault(row, DESCRIPTION, null);
-        return getRow(table, row);
+        currentRowDescription = row.getStringCellValueOrDefault(DESCRIPTION, null);
+        return getRow(row);
     }
 
     /**
      * @return security if found, null otherwise
      */
-    protected Security getSecurity(Table table, TableRow row, CashFlowType cashEventIfSecurityNotFound) {
+    protected Security getSecurity(TableRow row, CashFlowType cashEventIfSecurityNotFound) {
         try {
-            return getSecurityIfCan(table, row);
+            return getSecurityIfCan(row);
         } catch (Exception e) {
             EventCashFlow.EventCashFlowBuilder builder = EventCashFlow.builder()
                     .portfolio(getReport().getPortfolio())
-                    .timestamp(getReport().convertToInstant(table.getStringCellValue(row, DATE)))
-                    .currency(convertToCurrency(table.getStringCellValue(row, CURRENCY)))
-                    .description(table.getStringCellValueOrDefault(row, DESCRIPTION, null));
-            BigDecimal tax = getTax(table, row);
-            BigDecimal value = table.getCurrencyCellValue(row, VALUE)
+                    .timestamp(getReport().convertToInstant(row.getStringCellValue(DATE)))
+                    .currency(convertToCurrency(row.getStringCellValue(CURRENCY)))
+                    .description(row.getStringCellValueOrDefault(DESCRIPTION, null));
+            BigDecimal tax = getTax(row);
+            BigDecimal value = row.getBigDecimalCellValue(VALUE)
                     .add(tax.abs());
             EventCashFlow cash = builder
                     .eventType(cashEventIfSecurityNotFound)
@@ -116,8 +116,8 @@ abstract class PaymentsTable extends AbstractReportTable<SecurityEventCashFlow> 
         }
     }
 
-    protected Security getSecurityIfCan(Table table, TableRow row) {
-        String description = table.getStringCellValueOrDefault(row, DESCRIPTION, "");
+    protected Security getSecurityIfCan(TableRow row) {
+        String description = row.getStringCellValueOrDefault(DESCRIPTION, "");
         String descriptionLowercase = description.toLowerCase();
         for (ReportSecurityInformation info : securitiesIncomingCount) {
             if (info == null) continue;
@@ -135,8 +135,8 @@ abstract class PaymentsTable extends AbstractReportTable<SecurityEventCashFlow> 
         return securityParameter != null && description.contains(securityParameter.toLowerCase());
     }
 
-    protected BigDecimal getTax(Table table, TableRow row) {
-        String description = table.getStringCellValueOrDefault(row, DESCRIPTION, "");
+    protected BigDecimal getTax(TableRow row) {
+        String description = row.getStringCellValueOrDefault(DESCRIPTION, "");
         Matcher matcher = taxInformationPattern.matcher(description.toLowerCase());
         if (matcher.find()) {
             try {

--- a/src/main/java/ru/investbook/parser/uralsib/SecuritiesTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/SecuritiesTable.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.spacious_team.broker.pojo.Security;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
@@ -47,15 +46,15 @@ public class SecuritiesTable extends AbstractReportTable<ReportSecurityInformati
     }
 
     @Override
-    protected Collection<ReportSecurityInformation> getRow(Table table, TableRow row) {
+    protected Collection<ReportSecurityInformation> getRow(TableRow row) {
         Security security = Security.builder()
-                .id(table.getStringCellValue(row, ISIN))
-                .name(table.getStringCellValue(row, NAME))
+                .id(row.getStringCellValue(ISIN))
+                .name(row.getStringCellValue(NAME))
                 .build();
         return singletonList(ReportSecurityInformation.builder()
                 .security(security)
-                .cfi(table.getStringCellValue(row, CFI))
-                .incomingCount(table.getIntCellValue(row, INCOMING_COUNT))
+                .cfi(row.getStringCellValue(CFI))
+                .incomingCount(row.getIntCellValue(INCOMING_COUNT))
                 .build());
     }
 

--- a/src/main/java/ru/investbook/parser/uralsib/SecurityDepositAndWithdrawalTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/SecurityDepositAndWithdrawalTable.java
@@ -21,7 +21,6 @@ package ru.investbook.parser.uralsib;
 import org.spacious_team.broker.pojo.Security;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
 import org.spacious_team.broker.report_parser.api.SecurityTransaction;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableRow;
 
 import java.math.BigDecimal;
@@ -46,17 +45,17 @@ public class SecurityDepositAndWithdrawalTable extends AbstractReportTable<Secur
     }
 
     @Override
-    protected Collection<SecurityTransaction> getRow(Table table, TableRow row) {
-        String operation = table.getStringCellValue(row, OPERATION);
+    protected Collection<SecurityTransaction> getRow(TableRow row) {
+        String operation = row.getStringCellValue(OPERATION);
         if (!operation.equalsIgnoreCase(IN_DESCRIPTION) && !operation.equalsIgnoreCase(OUT_DESCRIPTION)) {
             return Collections.emptyList();
         }
         return Collections.singletonList(SecurityTransaction.builder()
-                .timestamp(convertToInstant(table.getStringCellValue(row, DATE)))
-                .transactionId(table.getStringCellValue(row, ID))
+                .timestamp(convertToInstant(row.getStringCellValue(DATE)))
+                .transactionId(row.getStringCellValue(ID))
                 .portfolio(getReport().getPortfolio())
-                .security(getSecurity(table, row).getId())
-                .count(table.getIntCellValue(row, COUNT))
+                .security(getSecurity(row).getId())
+                .count(row.getIntCellValue(COUNT))
                 .value(BigDecimal.ZERO)
                 .accruedInterest(BigDecimal.ZERO)
                 .commission(BigDecimal.ZERO)
@@ -65,8 +64,8 @@ public class SecurityDepositAndWithdrawalTable extends AbstractReportTable<Secur
                 .build());
     }
 
-    private Security getSecurity(Table table, TableRow row) {
-        String cfi = table.getStringCellValue(row, CFI);
+    private Security getSecurity(TableRow row) {
+        String cfi = row.getStringCellValue(CFI);
         return securitiesIncomingCount.stream()
                 .filter(security -> security.getCfi().equals(cfi))
                 .map(SecuritiesTable.ReportSecurityInformation::getSecurity)

--- a/src/main/java/ru/investbook/parser/uralsib/SecurityQuoteTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/SecurityQuoteTable.java
@@ -20,7 +20,6 @@ package ru.investbook.parser.uralsib;
 
 import org.spacious_team.broker.pojo.SecurityQuote;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableRow;
 
 import java.math.BigDecimal;
@@ -45,19 +44,19 @@ public class SecurityQuoteTable extends AbstractReportTable<SecurityQuote> {
     }
 
     @Override
-    protected Collection<SecurityQuote> getRow(Table table, TableRow row) {
-        BigDecimal amountInRub = table.getCurrencyCellValueOrDefault(row, AMOUNT, null);
+    protected Collection<SecurityQuote> getRow(TableRow row) {
+        BigDecimal amountInRub = row.getBigDecimalCellValueOrDefault(AMOUNT, null);
         if (amountInRub == null || amountInRub.compareTo(minValue) < 0) {
             return Collections.emptyList();
         }
-        int count = table.getIntCellValue(row, OUTGOING_COUNT);
+        int count = row.getIntCellValue(OUTGOING_COUNT);
         if (count == 0) {
             return Collections.emptyList();
         }
         BigDecimal priceInRub = amountInRub.divide(BigDecimal.valueOf(count), 4, HALF_UP);
-        BigDecimal quote = table.getCurrencyCellValue(row, QUOTE);
-        BigDecimal accruedInterest = table.getCurrencyCellValue(row, ACCRUED_INTEREST);
-        String isin = table.getStringCellValue(row, ISIN);
+        BigDecimal quote = row.getBigDecimalCellValue(QUOTE);
+        BigDecimal accruedInterest = row.getBigDecimalCellValue(ACCRUED_INTEREST);
+        String isin = row.getStringCellValue(ISIN);
         Instant reportEndDateTime = getReport().getReportEndDateTime();
         if (accruedInterest.compareTo(minValue) < 0) { // акция или облигация с НКД == 0 ?
             if (priceInRub.subtract(quote).abs().compareTo(minValue) < 0) {

--- a/src/main/java/ru/investbook/parser/uralsib/SecurityRedemptionTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/SecurityRedemptionTable.java
@@ -20,7 +20,6 @@ package ru.investbook.parser.uralsib;
 
 import lombok.Getter;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
@@ -47,11 +46,11 @@ public class SecurityRedemptionTable extends AbstractReportTable<Map.Entry<Strin
     }
 
     @Override
-    protected Collection<Map.Entry<String, Instant>> getRow(Table table, TableRow row) {
-        return table.getStringCellValue(row, OPERATION).equalsIgnoreCase(REDEMPTION_DESCRIPTION) ?
+    protected Collection<Map.Entry<String, Instant>> getRow(TableRow row) {
+        return row.getStringCellValue(OPERATION).equalsIgnoreCase(REDEMPTION_DESCRIPTION) ?
                 singletonList(new AbstractMap.SimpleEntry<>(
-                        table.getStringCellValue(row, NAME),
-                        convertToInstant(table.getStringCellValue(row, DATE)))) :
+                        row.getStringCellValue(NAME),
+                        convertToInstant(row.getStringCellValue(DATE)))) :
                 emptyList();
     }
 

--- a/src/main/java/ru/investbook/parser/uralsib/UralsibBrokerReport.java
+++ b/src/main/java/ru/investbook/parser/uralsib/UralsibBrokerReport.java
@@ -105,7 +105,7 @@ public class UralsibBrokerReport extends AbstractExcelBrokerReport {
             TableCellAddress address = reportPage.find(REPORT_DATE_MARKER, 0, Integer.MAX_VALUE,
                     (cell, value) -> cell.toLowerCase().contains(value.toString()));
             String[] words = reportPage.getCell(address)
-                    .getStringCellValue()
+                    .getStringValue()
                     .split(" ");
             return convertToInstant(words[words.length - 1])
                     .plus(LAST_TRADE_HOUR, ChronoUnit.HOURS);

--- a/src/main/java/ru/investbook/parser/vtb/CashFlowEventTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/CashFlowEventTable.java
@@ -25,12 +25,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.spacious_team.broker.pojo.CashFlowType;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
 import org.spacious_team.broker.report_parser.api.BrokerReport;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
 import org.spacious_team.table_wrapper.api.TableRow;
-import org.spacious_team.table_wrapper.excel.ExcelTable;
 import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
@@ -51,17 +49,17 @@ public class CashFlowEventTable extends AbstractReportTable<CashFlowEventTable.C
     }
 
     @Override
-    protected Collection<CashFlowEvent> getRow(Table table, TableRow row) {
-        String operation = table.getStringCellValueOrDefault(row, OPERATION, null);
+    protected Collection<CashFlowEvent> getRow(TableRow row) {
+        String operation = row.getStringCellValueOrDefault(OPERATION, null);
         if (operation == null) {
             return Collections.emptyList();
         }
         return Collections.singleton(CashFlowEvent.builder()
-                .date(((ExcelTable) table).getDateCellValue(row, DATE).toInstant())
+                .date(row.getInstantCellValue(DATE))
                 .operation(operation.toLowerCase().trim())
-                .value(table.getCurrencyCellValue(row, VALUE))
-                .currency(VtbBrokerReport.convertToCurrency(table.getStringCellValue(row, CURRENCY)))
-                .description(table.getStringCellValueOrDefault(row, DESCRIPTION, ""))
+                .value(row.getBigDecimalCellValue(VALUE))
+                .currency(VtbBrokerReport.convertToCurrency(row.getStringCellValue(CURRENCY)))
+                .description(row.getStringCellValueOrDefault(DESCRIPTION, ""))
                 .build());
     }
 

--- a/src/main/java/ru/investbook/parser/vtb/VtbBrokerReport.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbBrokerReport.java
@@ -80,7 +80,7 @@ public class VtbBrokerReport extends AbstractExcelBrokerReport {
         try {
             TableCellAddress address = reportPage.find(REPORT_DATE_MARKER, 1, 2);
             String value = reportPage.getCell(address)
-                    .getStringCellValue()
+                    .getStringValue()
                     .split(" ")[9];
             return convertToInstant(value)
                     .plus(LAST_TRADE_HOUR, ChronoUnit.HOURS);

--- a/src/main/java/ru/investbook/parser/vtb/VtbCashTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbCashTable.java
@@ -26,7 +26,6 @@ import org.spacious_team.broker.report_parser.api.BrokerReport;
 import org.spacious_team.broker.report_parser.api.PortfolioCash;
 import org.spacious_team.table_wrapper.api.MultiLineTableColumn;
 import org.spacious_team.table_wrapper.api.OptionalTableColumn;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
@@ -48,23 +47,23 @@ public class VtbCashTable extends AbstractReportTable<PortfolioCash> {
     }
 
     @Override
-    protected Collection<PortfolioCash> getRow(Table table, TableRow row) {
+    protected Collection<PortfolioCash> getRow(TableRow row) {
         Collection<PortfolioCash> cashes = new ArrayList<>();
-        cashes.addAll(getPortfolioCash(table, row, VtbCashTableHeader.STOCK_MARKET, "основной рынок"));
-        cashes.addAll(getPortfolioCash(table, row, VtbCashTableHeader.FORTS_MARKET, "срочный рынок"));
-        cashes.addAll(getPortfolioCash(table, row, VtbCashTableHeader.NON_MARKET, "внебирж. рынок"));
+        cashes.addAll(getPortfolioCash(row, VtbCashTableHeader.STOCK_MARKET, "основной рынок"));
+        cashes.addAll(getPortfolioCash(row, VtbCashTableHeader.FORTS_MARKET, "срочный рынок"));
+        cashes.addAll(getPortfolioCash(row, VtbCashTableHeader.NON_MARKET, "внебирж. рынок"));
         return cashes;
     }
 
-    private Collection<PortfolioCash> getPortfolioCash(Table table, TableRow row, VtbCashTableHeader column, String section) {
+    private Collection<PortfolioCash> getPortfolioCash(TableRow row, VtbCashTableHeader column, String section) {
         try {
             return Collections.singleton(PortfolioCash.builder()
-                    .currency(VtbBrokerReport.convertToCurrency(table.getStringCellValue(row, VtbCashTableHeader.CURRENCY)))
+                    .currency(VtbBrokerReport.convertToCurrency(row.getStringCellValue(VtbCashTableHeader.CURRENCY)))
                     .section(section)
-                    .value(table.getCurrencyCellValue(row, column))
+                    .value(row.getBigDecimalCellValue(column))
                     .build());
         } catch (Exception e) {
-            log.debug("Отсутствует значение колонки '{}' в таблице {}", column, table);
+            log.debug("Отсутствует значение колонки '{}' в таблице {}", column, row.getTable());
             return Collections.emptyList();
         }
     }

--- a/src/main/java/ru/investbook/parser/vtb/VtbDerivativeTransactionTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbDerivativeTransactionTable.java
@@ -22,12 +22,10 @@ import lombok.Getter;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
 import org.spacious_team.broker.report_parser.api.BrokerReport;
 import org.spacious_team.broker.report_parser.api.DerivativeTransaction;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
 import org.spacious_team.table_wrapper.api.TableRow;
-import org.spacious_team.table_wrapper.excel.ExcelTable;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -44,22 +42,22 @@ public class VtbDerivativeTransactionTable extends AbstractReportTable<Derivativ
     }
 
     @Override
-    protected Collection<DerivativeTransaction> getRow(Table table, TableRow row) {
+    protected Collection<DerivativeTransaction> getRow(TableRow row) {
 
-        boolean isBuy = table.getStringCellValue(row, DIRECTION).equalsIgnoreCase("покупка");
-        int count = table.getIntCellValue(row, COUNT);
-        BigDecimal valueInPoints = table.getCurrencyCellValue(row, QUOTE).multiply(BigDecimal.valueOf(count));
+        boolean isBuy = row.getStringCellValue(DIRECTION).equalsIgnoreCase("покупка");
+        int count = row.getIntCellValue(COUNT);
+        BigDecimal valueInPoints = row.getBigDecimalCellValue(QUOTE).multiply(BigDecimal.valueOf(count));
         if (isBuy) {
             valueInPoints = valueInPoints.negate();
         }
-        BigDecimal commission = table.getCurrencyCellValue(row, BROKER_CLEARING_COMMISSION)
-                .add(table.getCurrencyCellValue(row, BROKER_TRANSACTION_COMMISSION))
+        BigDecimal commission = row.getBigDecimalCellValue(BROKER_CLEARING_COMMISSION)
+                .add(row.getBigDecimalCellValue(BROKER_TRANSACTION_COMMISSION))
                 .negate();
         return Collections.singleton(DerivativeTransaction.builder()
-                .timestamp(((ExcelTable) table).getDateCellValue(row, DATE_TIME).toInstant())
-                .transactionId(table.getStringCellValue(row, TRANSACTION))
+                .timestamp(row.getInstantCellValue(DATE_TIME))
+                .transactionId(row.getStringCellValue(TRANSACTION))
                 .portfolio(getReport().getPortfolio())
-                .security(table.getStringCellValue(row, CONTRACT))
+                .security(row.getStringCellValue(CONTRACT))
                 .count((isBuy ? 1 : -1) * count)
                 .valueInPoints(valueInPoints)
                 .commission(commission)

--- a/src/main/java/ru/investbook/parser/vtb/VtbForeignExchangeTransactionTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbForeignExchangeTransactionTable.java
@@ -22,12 +22,10 @@ import lombok.Getter;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
 import org.spacious_team.broker.report_parser.api.BrokerReport;
 import org.spacious_team.broker.report_parser.api.ForeignExchangeTransaction;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
 import org.spacious_team.table_wrapper.api.TableRow;
-import org.spacious_team.table_wrapper.excel.ExcelTable;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -44,24 +42,24 @@ public class VtbForeignExchangeTransactionTable extends AbstractReportTable<Fore
     }
 
     @Override
-    protected Collection<ForeignExchangeTransaction> getRow(Table table, TableRow row) {
-        boolean isBuy = table.getStringCellValue(row, DIRECTION).trim().equalsIgnoreCase("Покупка");
-        BigDecimal value = table.getCurrencyCellValue(row, VALUE);
+    protected Collection<ForeignExchangeTransaction> getRow(TableRow row) {
+        boolean isBuy = row.getStringCellValue(DIRECTION).trim().equalsIgnoreCase("Покупка");
+        BigDecimal value = row.getBigDecimalCellValue(VALUE);
         if (isBuy) {
             value = value.negate();
         }
-        BigDecimal commission = table.getCurrencyCellValue(row, MARKET_COMMISSION)
-                .add(table.getCurrencyCellValue(row, BROKER_COMMISSION))
+        BigDecimal commission = row.getBigDecimalCellValue(MARKET_COMMISSION)
+                .add(row.getBigDecimalCellValue(BROKER_COMMISSION))
                 .negate();
         return Collections.singletonList(ForeignExchangeTransaction.builder()
-                .timestamp(((ExcelTable) table).getDateCellValue(row, DATE_TIME).toInstant())
-                .transactionId(table.getStringCellValue(row, TRANSACTION))
+                .timestamp(row.getInstantCellValue(DATE_TIME))
+                .transactionId(row.getStringCellValue(TRANSACTION))
                 .portfolio(getReport().getPortfolio())
-                .security(table.getStringCellValue(row, INSTRUMENT))
-                .count((isBuy ? 1 : -1) * table.getIntCellValue(row, COUNT))
+                .security(row.getStringCellValue(INSTRUMENT))
+                .count((isBuy ? 1 : -1) * row.getIntCellValue(COUNT))
                 .value(value)
                 .commission(commission)
-                .valueCurrency(VtbBrokerReport.convertToCurrency(table.getStringCellValue(row, VALUE_CURRENCY)))
+                .valueCurrency(VtbBrokerReport.convertToCurrency(row.getStringCellValue(VALUE_CURRENCY)))
                 .commissionCurrency("RUB")
                 .build());
     }

--- a/src/main/java/ru/investbook/parser/vtb/VtbSecuritiesTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbSecuritiesTable.java
@@ -23,7 +23,6 @@ import lombok.RequiredArgsConstructor;
 import org.spacious_team.broker.pojo.Security;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
 import org.spacious_team.broker.report_parser.api.BrokerReport;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
@@ -49,11 +48,11 @@ public class VtbSecuritiesTable extends AbstractReportTable<Security> {
     }
 
     @Override
-    protected Collection<Security> getRow(Table table, TableRow row) {
-        if (table.getCellValue(row, SECTION) == null) {
+    protected Collection<Security> getRow(TableRow row) {
+        if (row.getCellValue(SECTION) == null) {
             return Collections.emptyList(); // sub-header row
         }
-        String[] description = table.getStringCellValue(row, NAME_REGNUMBER_ISIN).split(",");
+        String[] description = row.getStringCellValue(NAME_REGNUMBER_ISIN).split(",");
         String name = description[0].trim();
         String registrationNumber = description[1].toUpperCase().trim();
         String isin = description[2].toUpperCase().trim();

--- a/src/main/java/ru/investbook/parser/vtb/VtbSecurityDepositAndWithdrawalTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbSecurityDepositAndWithdrawalTable.java
@@ -21,9 +21,7 @@ package ru.investbook.parser.vtb;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
 import org.spacious_team.broker.report_parser.api.BrokerReport;
 import org.spacious_team.broker.report_parser.api.SecurityTransaction;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableRow;
-import org.spacious_team.table_wrapper.excel.ExcelTable;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -46,8 +44,8 @@ public class VtbSecurityDepositAndWithdrawalTable  extends AbstractReportTable<S
     }
 
     @Override
-    protected Collection<SecurityTransaction> getRow(Table table, TableRow row) {
-        String operation = table.getStringCellValueOrDefault(row, OPERATION, "").toLowerCase().trim();
+    protected Collection<SecurityTransaction> getRow(TableRow row) {
+        String operation = row.getStringCellValueOrDefault(OPERATION, "").toLowerCase().trim();
         switch (operation) {
             case "перевод цб": // перевод между субсчетами
             case "конвертация цб":
@@ -55,8 +53,8 @@ public class VtbSecurityDepositAndWithdrawalTable  extends AbstractReportTable<S
             case "ввод цб": // догадка, нет примера отчета
                 break;
             case "погашение цб":
-                String isin = table.getStringCellValue(row, NAME_REGNUMBER_ISIN).split(",")[2].trim();
-                Integer count = Math.abs(table.getIntCellValue(row, COUNT));
+                String isin = row.getStringCellValue(NAME_REGNUMBER_ISIN).split(",")[2].trim();
+                Integer count = Math.abs(row.getIntCellValue(COUNT));
                 bondRedemptions.put(isin, count);
                 // no break;
             default:
@@ -64,8 +62,8 @@ public class VtbSecurityDepositAndWithdrawalTable  extends AbstractReportTable<S
         }
 
         String portfolio = getReport().getPortfolio();
-        String isin = table.getStringCellValue(row, NAME_REGNUMBER_ISIN).split(",")[2].trim();
-        Instant timestamp = ((ExcelTable) table).getDateCellValue(row, DATE).toInstant();
+        String isin = row.getStringCellValue(NAME_REGNUMBER_ISIN).split(",")[2].trim();
+        Instant timestamp = row.getInstantCellValue(DATE);
         String transactionId = generateTransactionId(portfolio, timestamp, isin);
         return Collections.singleton(
                 SecurityTransaction.builder()
@@ -73,7 +71,7 @@ public class VtbSecurityDepositAndWithdrawalTable  extends AbstractReportTable<S
                         .timestamp(timestamp)
                         .portfolio(portfolio)
                         .security(isin)
-                        .count(table.getIntCellValue(row, COUNT))
+                        .count(row.getIntCellValue(COUNT))
                         .value(BigDecimal.ZERO)
                         .accruedInterest(BigDecimal.ZERO)
                         .commission(BigDecimal.ZERO)

--- a/src/main/java/ru/investbook/parser/vtb/VtbSecurityFlowTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbSecurityFlowTable.java
@@ -23,7 +23,6 @@ import lombok.RequiredArgsConstructor;
 import org.spacious_team.broker.pojo.Security;
 import org.spacious_team.broker.report_parser.api.AbstractReportTable;
 import org.spacious_team.broker.report_parser.api.BrokerReport;
-import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableColumn;
 import org.spacious_team.table_wrapper.api.TableColumnDescription;
 import org.spacious_team.table_wrapper.api.TableColumnImpl;
@@ -46,8 +45,8 @@ public class VtbSecurityFlowTable extends AbstractReportTable<Security> {
     }
 
     @Override
-    protected Collection<Security> getRow(Table table, TableRow row) {
-        String[] description = table.getStringCellValue(row, NAME_REGNUMBER_ISIN).split(",");
+    protected Collection<Security> getRow(TableRow row) {
+        String[] description = row.getStringCellValue(NAME_REGNUMBER_ISIN).split(",");
         String name = description[0].trim();
         String registrationNumber = description[1].toUpperCase().trim();
         String isin = description[2].toUpperCase().trim();


### PR DESCRIPTION
Обновлены API и реализующие их библиотеки для возможности использования `Table.stream()`. Реализации `table-wrapper-excel-impl` и `table-wrapper-xml-impl` теперь используют generic (более строгая проверка типов) с реализацией интерфейса Cell DAO (рефакторинг). Быстродействие и объем генерации мусора реализаций сохранено на прежнем уровне.
Relates #189