### PR TITLE
Улучшение графика роста активов

### DIFF
--- a/src/main/java/ru/investbook/report/excel/ExcelTableHeader.java
+++ b/src/main/java/ru/investbook/report/excel/ExcelTableHeader.java
@@ -20,6 +20,8 @@ package ru.investbook.report.excel;
 
 import ru.investbook.report.TableHeader;
 
+import static java.lang.String.valueOf;
+
 public interface ExcelTableHeader extends TableHeader {
     String ROW_NUM_PLACE_HOLDER = "{rowNum}";
 
@@ -29,6 +31,12 @@ public interface ExcelTableHeader extends TableHeader {
 
     default String getCellAddr(int rowNum) {
         return "" + getColumnIndex() + rowNum;
+    }
+
+    default String getRelativeCellAddr(int rowDelta, int columnDelta) {
+        String _rowDelta = (rowDelta < 0) ? valueOf(rowDelta) : ("+" + rowDelta);
+        char column = (char) ('A' + this.ordinal() + columnDelta);
+        return "INDIRECT(\"" + column + "\" & ROW() " + _rowDelta + ")";
     }
 
     default char getColumnIndex() {

--- a/src/main/java/ru/investbook/report/excel/PortfolioAnalysisExcelTableFactory.java
+++ b/src/main/java/ru/investbook/report/excel/PortfolioAnalysisExcelTableFactory.java
@@ -64,6 +64,7 @@ import static org.spacious_team.broker.pojo.CashFlowType.CASH;
 import static ru.investbook.report.ForeignExchangeRateService.RUB;
 import static ru.investbook.report.excel.ExcelTableHeader.getColumnsRange;
 import static ru.investbook.report.excel.PortfolioAnalysisExcelTableHeader.*;
+import static ru.investbook.report.excel.PortfolioStatusExcelTableFactory.minCash;
 
 @Component
 @RequiredArgsConstructor
@@ -167,11 +168,10 @@ public class PortfolioAnalysisExcelTableFactory implements TableFactory {
     private static void addAssetsGrowthColumn(Table table) {
         boolean isTotalInvestmentUsdKnown = false;
         for (var record : table) {
-            if (!isTotalInvestmentUsdKnown && record.containsKey(TOTAL_INVESTMENT_USD)) {
-                isTotalInvestmentUsdKnown = true;
-            }
+            isTotalInvestmentUsdKnown = isTotalInvestmentUsdKnown || record.containsKey(TOTAL_INVESTMENT_USD);
             if (isTotalInvestmentUsdKnown) {
-                record.putIfAbsent(TOTAL_INVESTMENT_USD, "=INDIRECT(\"" + TOTAL_INVESTMENT_USD.getColumnIndex() + "\" & ROW() - 1)");
+                record.computeIfAbsent(TOTAL_INVESTMENT_USD,
+                        $ -> "=" + TOTAL_INVESTMENT_USD.getRelativeCellAddr(-1, 0));
                 BigDecimal assetsRub = (BigDecimal) record.get(ASSETS_RUB);
                 if (assetsRub != null && assetsRub.compareTo(minCash) > 0) {
                     record.put(ASSETS_GROWTH, ASSETS_GROWTH_FORMULA);
@@ -190,7 +190,7 @@ public class PortfolioAnalysisExcelTableFactory implements TableFactory {
                 record.put(SP500, value);
                 record.put(SP500_GROWTH, SP500_GROWTH_FORMULA);
             } else if (isSp500ValueKnown) {
-                record.put(SP500, "=INDIRECT(\"" + SP500.getColumnIndex() + "\" & ROW() - 1)");
+                record.put(SP500, "=" + SP500.getRelativeCellAddr(-1, 0));
                 record.put(SP500_GROWTH, SP500_GROWTH_FORMULA);
             }
         }

--- a/src/main/java/ru/investbook/repository/PortfolioPropertyRepository.java
+++ b/src/main/java/ru/investbook/repository/PortfolioPropertyRepository.java
@@ -80,13 +80,13 @@ public interface PortfolioPropertyRepository extends JpaRepository<PortfolioProp
             @Param("from") Instant startDate,
             @Param("to") Instant endDate);
 
-    List<PortfolioPropertyEntity> findByPropertyAndTimestampBetweenOrderByTimestampDesc(String property,
-                                                                                        Instant startDate,
-                                                                                        Instant endDate);
+    List<PortfolioPropertyEntity> findByPropertyInAndTimestampBetweenOrderByTimestampDesc(Collection<String> properties,
+                                                                                          Instant startDate,
+                                                                                          Instant endDate);
 
-    List<PortfolioPropertyEntity> findByPortfolioIdInAndPropertyAndTimestampBetweenOrderByTimestampDesc(
+    List<PortfolioPropertyEntity> findByPortfolioIdInAndPropertyInAndTimestampBetweenOrderByTimestampDesc(
             Collection<String> portfolios,
-            String property,
+            Collection<String> properties,
             Instant startDate,
             Instant endDate);
 }


### PR DESCRIPTION
В таблице Обзор, которая учитывает все портфели суммируются Активы портфелей. Если за какую-то дату у одного или более портфелей не известы Активы, можно использовать предыдущее значение (как сейчас), увеличенное на сумму инвестиций за период.
Это позволит избежать провалов на графике роста активов, образующихся потому что инвестиции растут (учитывают все даты инвестиций за год), а Активы подгружаются из отчета только на дату конца отчета.