### PR TITLE
Улучшен алгоритм расчета графика роста активов в процентах

### DIFF
--- a/src/main/java/ru/investbook/report/ForeignExchangeRateService.java
+++ b/src/main/java/ru/investbook/report/ForeignExchangeRateService.java
@@ -67,13 +67,13 @@ public class ForeignExchangeRateService {
         if (exchangeRate != null) {
             return exchangeRate;
         } else if (baseCurrency.equalsIgnoreCase("RUB")) {
-            exchangeRate = BigDecimal.ONE.divide(getExchangeRateToRub(quoteCurrency), 6, RoundingMode.HALF_UP);
+            exchangeRate = BigDecimal.ONE.divide(getExchangeRateToRub(quoteCurrency), 20, RoundingMode.HALF_UP);
         } else if (quoteCurrency.equalsIgnoreCase("RUB")) {
             exchangeRate = getExchangeRateToRub(baseCurrency);
         } else {
             BigDecimal baseToRub = getExchangeRateToRub(baseCurrency);
             BigDecimal quoteToRub = getExchangeRateToRub(quoteCurrency);
-            exchangeRate = baseToRub.divide(quoteToRub, 6, RoundingMode.HALF_UP);
+            exchangeRate = baseToRub.divide(quoteToRub, 20, RoundingMode.HALF_UP);
         }
         cache(baseCurrency, quoteCurrency, exchangeRate);
         return exchangeRate;
@@ -115,7 +115,7 @@ public class ForeignExchangeRateService {
         } catch (Exception e) {
             BigDecimal baseToRub = getExchangeRateToRubOrDefault(baseCurrency, atDate);
             BigDecimal quoteToRub = getExchangeRateToRubOrDefault(quoteCurrency, atDate);
-            BigDecimal defaultExchangeRate = baseToRub.divide(quoteToRub, 6, RoundingMode.HALF_UP);
+            BigDecimal defaultExchangeRate = baseToRub.divide(quoteToRub, 20, RoundingMode.HALF_UP);
             log.warn("Курс валюты {}{} на дату {} не известен, использую ориентировочное значение {}",
                     baseCurrency, quoteCurrency, atDate, defaultExchangeRate);
             return defaultExchangeRate;
@@ -139,13 +139,13 @@ public class ForeignExchangeRateService {
         if (exchangeRate != null) {
             return exchangeRate;
         } else if (baseCurrency.equalsIgnoreCase("RUB")) {
-            exchangeRate = BigDecimal.ONE.divide(getExchangeRateToRub(quoteCurrency, atDate), 6, RoundingMode.HALF_UP);
+            exchangeRate = BigDecimal.ONE.divide(getExchangeRateToRub(quoteCurrency, atDate), 20, RoundingMode.HALF_UP);
         } else if (quoteCurrency.equalsIgnoreCase("RUB")) {
             exchangeRate = getExchangeRateToRub(baseCurrency, atDate);
         } else {
             BigDecimal baseToRub = getExchangeRateToRub(baseCurrency, atDate);
             BigDecimal quoteToRub = getExchangeRateToRub(quoteCurrency, atDate);
-            exchangeRate = baseToRub.divide(quoteToRub, 6, RoundingMode.HALF_UP);
+            exchangeRate = baseToRub.divide(quoteToRub, 20, RoundingMode.HALF_UP);
         }
         cache(baseCurrency, quoteCurrency, atDate, exchangeRate);
         return exchangeRate;

--- a/src/main/java/ru/investbook/report/excel/PortfolioAnalysisExcelTableFactory.java
+++ b/src/main/java/ru/investbook/report/excel/PortfolioAnalysisExcelTableFactory.java
@@ -173,15 +173,17 @@ public class PortfolioAnalysisExcelTableFactory implements TableFactory {
             double usdToRubExchangeRate = foreignExchangeRateService.getExchangeRateToRub("USD").doubleValue();
             Double divider = null;
             double investmentUsd = 0;
+            Double prevAssetsGrownValue = null;
             for (var record : table) {
                 investmentUsd += getInvestmentUsd(record, usdToRubExchangeRate);
                 Number assetsRub = (Number) record.get(ASSETS_RUB);
                 if (assetsRub != null) {
                     double assetsUsd = assetsRub.doubleValue() / usdToRubExchangeRate;
-                    divider = updateDivider(divider, assetsUsd, investmentUsd);
+                    divider = updateDivider(divider, assetsUsd, investmentUsd, prevAssetsGrownValue);
                     investmentUsd = 0;
                     if (divider != null) {
                         record.put(ASSETS_GROWTH, "=(" + ASSETS_USD.getCellAddr() + "/" + divider + "-1)*100");
+                        prevAssetsGrownValue = assetsUsd / divider;
                     }
                 }
             }
@@ -206,9 +208,16 @@ public class PortfolioAnalysisExcelTableFactory implements TableFactory {
         return 0;
     }
 
-    private Double updateDivider(Double divider, double assetsUsd, double investmentUsd) {
+    private Double updateDivider(Double divider, double assetsUsd, double investmentUsd, Double prevAssetsGrowth) {
         if (divider == null) {
-            divider = assetsUsd;
+            if (prevAssetsGrowth == null) {
+                // начинаем график роста активов с нулевой отметки
+                divider = assetsUsd;
+            } else {
+                // счет был опустошен, сейчас деньги снова заведены,
+                // график роста активов остановился на отметке prevAssetsGrowth, начинаем с него же
+                divider = assetsUsd / prevAssetsGrowth;
+            }
         } else {
             double assetsBeforeInvestment = assetsUsd - investmentUsd;
             divider = divider * assetsUsd / assetsBeforeInvestment;


### PR DESCRIPTION
1. Исправлено: не хватало точности 6 знаков после запятой для курса RUBUSD. Из-за этого ранее на графике мог быть скачек, если активы выводились к около нулевым значениям.
2. Улучшение: теперь если со счета снять все деньги, а потом снова завести, то график роста продолжит рост (ранее график после каждого снятия под ноль начинал рост с нулевого значения). Полезно для отдельного счета под валютную секцию биржи, с которой периодически ДС выводятся под ноль.

Closes gh-334