### PR TITLE
fix ВТБ - не распознаются купоны

### DIFF
--- a/src/main/java/ru/investbook/parser/vtb/VtbSecuritiesTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbSecuritiesTable.java
@@ -53,7 +53,7 @@ public class VtbSecuritiesTable extends SingleAbstractReportTable<Security> {
         String description = row.getStringCellValue(NAME_REGNUMBER_ISIN);
         Security security = VtbReportHelper.getSecurity(description);
         int securityId = getReport().getSecurityRegistrar().declareStockOrBond(security.getIsin(), security::toBuilder);
-        security = Security.builder().id(securityId).build();
+        security = security.toBuilder().id(securityId).build();
         String registrationNumber = description.split(",")[1].toUpperCase().trim();
         regNumberToSecurity.put(registrationNumber, security);
         return security;

--- a/src/main/java/ru/investbook/parser/vtb/VtbSecurityFlowTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbSecurityFlowTable.java
@@ -47,7 +47,7 @@ public class VtbSecurityFlowTable extends SingleAbstractReportTable<Security> {
         String description = row.getStringCellValue(NAME_REGNUMBER_ISIN);
         Security security = VtbReportHelper.getSecurity(description);
         int securityId = getReport().getSecurityRegistrar().declareStockOrBond(security.getIsin(), security::toBuilder);
-        security = Security.builder().id(securityId).build();
+        security = security.toBuilder().id(securityId).build();
         String registrationNumber = description.split(",")[1].toUpperCase().trim();
         regNumberToSecurity.put(registrationNumber, security);
         return security;


### PR DESCRIPTION
В ru/investbook/parser/vtb/VtbCouponAmortizationRedemptionTable.java:84 используется security.getIsin(), но в ru/investbook/parser/vtb/VtbCouponAmortizationRedemptionTable.java:74 возвращается Security без ISIN. Фикс заполняет все поля найденного Security, а не только id.