### PR TITLE
Не отображать в Execl отчете данные по архивным счетам

### DIFF
--- a/src/main/java/ru/investbook/web/InvestbookReportController.java
+++ b/src/main/java/ru/investbook/web/InvestbookReportController.java
@@ -67,7 +67,9 @@ public class InvestbookReportController {
 
     @GetMapping
     public void buildInvestbookReportByGet(HttpServletResponse response) throws IOException {
-        buildInvestbookReport(new ViewFilterModel(), response);
+        ViewFilterModel viewFilter = new ViewFilterModel();
+        viewFilter.setPortfolios(getActivePortfolios(portfolioRepository));
+        buildInvestbookReport(viewFilter, response);
     }
 
     @PostMapping


### PR DESCRIPTION
На главной странице по ссылке "Детальная информация" отображать информацию только по активным счетам. Это ожидаемо, т.к. на главной странице активы и остатки ДС отображаются только для активных счетов.

По всем счетам выгрузку можно сформировать по ссылке "Аналитика с настройками".