### PR TITLE
Доработки фильтров и навигации для таблицы Форм

### DIFF
--- a/.idea/inspectionProfiles/Spelling_checks.xml
+++ b/.idea/inspectionProfiles/Spelling_checks.xml
@@ -1,0 +1,10 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Spelling checks" />
+    <inspection_tool class="ConstantConditions" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="true" />
+      <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="false" />
+    </inspection_tool>
+    <inspection_tool class="VariableTypeCanBeExplicit" enabled="true" level="WARNING" enabled_by_default="true" editorAttributes="WARNING_ATTRIBUTES" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/Spelling_checks.xml
+++ b/.idea/inspectionProfiles/Spelling_checks.xml
@@ -5,6 +5,22 @@
       <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="true" />
       <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="false" />
     </inspection_tool>
+    <inspection_tool class="NullableProblems" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="REPORT_NULLABLE_METHOD_OVERRIDES_NOTNULL" value="true" />
+      <option name="REPORT_NOT_ANNOTATED_METHOD_OVERRIDES_NOTNULL" value="false" />
+      <option name="REPORT_NOTNULL_PARAMETER_OVERRIDES_NULLABLE" value="true" />
+      <option name="REPORT_NOT_ANNOTATED_PARAMETER_OVERRIDES_NOTNULL" value="true" />
+      <option name="REPORT_NOT_ANNOTATED_GETTER" value="true" />
+      <option name="REPORT_NOT_ANNOTATED_SETTER_PARAMETER" value="true" />
+      <option name="REPORT_ANNOTATION_NOT_PROPAGATED_TO_OVERRIDERS" value="false" />
+      <option name="REPORT_NULLS_PASSED_TO_NON_ANNOTATED_METHOD" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ReturnNull" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="m_reportObjectMethods" value="true" />
+      <option name="m_reportArrayMethods" value="true" />
+      <option name="m_reportCollectionMethods" value="true" />
+      <option name="m_ignorePrivateMethods" value="false" />
+    </inspection_tool>
     <inspection_tool class="VariableTypeCanBeExplicit" enabled="true" level="WARNING" enabled_by_default="true" editorAttributes="WARNING_ATTRIBUTES" />
   </profile>
 </component>

--- a/src/main/java/ru/investbook/parser/vtb/AbstractVtbCashFlowTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/AbstractVtbCashFlowTable.java
@@ -79,8 +79,7 @@ public abstract class AbstractVtbCashFlowTable<RowType> extends SingleInitializa
                     left.addAll(right);
                     return left;
                 },
-                Collector.Characteristics.IDENTITY_FINISH
-        );
+                Collector.Characteristics.IDENTITY_FINISH);
     }
 
     protected abstract Collection<RowType> getRow(CashFlowEventTable.CashFlowEvent event);

--- a/src/main/java/ru/investbook/report/excel/ExcelView.java
+++ b/src/main/java/ru/investbook/report/excel/ExcelView.java
@@ -69,7 +69,7 @@ public class ExcelView {
             idx += delta;
             delta = cpuCnt;
             int toIndex = min(idx, usedExcelTableViews.size());
-            final var tables = usedExcelTableViews.subList(fromIndex, toIndex)
+            List<ExcelTable> tables = usedExcelTableViews.subList(fromIndex, toIndex)
                     .parallelStream()
                     .map(excelTableView -> getExcelTables(excelTableView, filter))
                     .flatMap(Collection::stream)

--- a/src/main/java/ru/investbook/report/excel/PortfolioAnalysisExcelTableFactory.java
+++ b/src/main/java/ru/investbook/report/excel/PortfolioAnalysisExcelTableFactory.java
@@ -141,7 +141,7 @@ public class PortfolioAnalysisExcelTableFactory implements TableFactory {
     }
 
     private void addCashBalanceColumns(LinkedHashMap<Instant, Map<String, BigDecimal>> cashBalances, Table table) {
-        for (var entry : cashBalances.entrySet()) {
+        for (Map.Entry<Instant, Map<String, BigDecimal>> entry : cashBalances.entrySet()) {
             Instant instant = entry.getKey();
             Table.Record record = recordOf(table, instant);
             Map<String, BigDecimal> currencyValue = entry.getValue();
@@ -160,7 +160,7 @@ public class PortfolioAnalysisExcelTableFactory implements TableFactory {
     }
 
     private void addAssetsColumns(LinkedHashMap<Instant, BigDecimal> totalAssets, Table table) {
-        for (var entry : totalAssets.entrySet()) {
+        for (Map.Entry<Instant, BigDecimal> entry : totalAssets.entrySet()) {
             Instant instant = entry.getKey();
             BigDecimal assets = entry.getValue();
             Table.Record record = recordOf(table, instant);
@@ -177,7 +177,7 @@ public class PortfolioAnalysisExcelTableFactory implements TableFactory {
             Double divider = null;
             double investmentUsd = 0;
             Double prevAssetsGrownValue = null;
-            for (var record : table) {
+            for (Table.Record record : table) {
                 investmentUsd += getInvestmentUsd(record, usdToRubExchangeRate);
                 Number assetsRub = (Number) record.get(ASSETS_RUB);
                 if (assetsRub != null) {
@@ -231,7 +231,7 @@ public class PortfolioAnalysisExcelTableFactory implements TableFactory {
 
     private static void addSp500GrowthColumn(Map<LocalDate, BigDecimal> sp500, Table table) {
         boolean isSp500ValueKnown = false;
-        for (var record : table) {
+        for (Table.Record record : table) {
             LocalDate date = (LocalDate) record.get(DATE);
             BigDecimal value = sp500.get(date);
             if (value != null) {
@@ -247,7 +247,7 @@ public class PortfolioAnalysisExcelTableFactory implements TableFactory {
 
     private void fillEmptyTotalInvestmentCells(Table table) {
         boolean isTotalInvestmentUsdKnown = false;
-        for (var record : table) {
+        for (Table.Record record : table) {
             isTotalInvestmentUsdKnown = isTotalInvestmentUsdKnown || record.containsKey(TOTAL_INVESTMENT_USD);
             if (isTotalInvestmentUsdKnown) {
                 record.computeIfAbsent(TOTAL_INVESTMENT_USD,
@@ -393,7 +393,7 @@ public class PortfolioAnalysisExcelTableFactory implements TableFactory {
     }
 
     private static List<PortfolioInstantCurrencyValue> sumCashWithSameCurrency(List<PortfolioCash> portfolioCashes) {
-        var portfolioTimestampCurrencyMap = portfolioCashes.stream()
+        Map<String, Map<Instant, Map<String, BigDecimal>>> portfolioTimestampCurrencyMap = portfolioCashes.stream()
                 .collect(
                         groupingBy(PortfolioCash::getPortfolio,
                                 groupingBy(PortfolioCash::getTimestamp,

--- a/src/main/java/ru/investbook/repository/SecurityDescriptionRepository.java
+++ b/src/main/java/ru/investbook/repository/SecurityDescriptionRepository.java
@@ -44,7 +44,7 @@ public interface SecurityDescriptionRepository extends JpaRepository<SecurityDes
     @Transactional
     default void createSectorIfNotExists(int securityId, String sector) {
         if (!existsById(securityId)) {
-            var entity = new SecurityDescriptionEntity();
+            SecurityDescriptionEntity entity = new SecurityDescriptionEntity();
             entity.setSecurity(securityId);
             entity.setSector(sector);
             saveAndFlush(entity);

--- a/src/main/java/ru/investbook/repository/specs/EventCashFlowEntitySearchSpecification.java
+++ b/src/main/java/ru/investbook/repository/specs/EventCashFlowEntitySearchSpecification.java
@@ -20,12 +20,14 @@ package ru.investbook.repository.specs;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.lang.Nullable;
 import ru.investbook.entity.EventCashFlowEntity;
 import ru.investbook.entity.EventCashFlowEntity_;
 import ru.investbook.entity.PortfolioEntity_;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import java.time.LocalDate;
@@ -44,49 +46,44 @@ public class EventCashFlowEntitySearchSpecification implements Specification<Eve
 
     @Override
     public Predicate toPredicate(Root<EventCashFlowEntity> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
-
         return Stream.of(
                         getPortfolioPredicate(root, builder),
                         getDateFromPredicate(root, builder),
-                        getDateToPredicate(root, builder)
-                )
+                        getDateToPredicate(root, builder))
                 .filter(Objects::nonNull)
                 .reduce(builder::and)
                 .orElseGet(builder::conjunction);
     }
 
     private Predicate getPortfolioPredicate(Root<EventCashFlowEntity> root, CriteriaBuilder builder) {
-        Predicate predicate;
         if (hasText(portfolio)) {
-            predicate = builder.equal(
-                    root.get(EventCashFlowEntity_.portfolio).get(PortfolioEntity_.ID),
-                    portfolio
-            );
-        } else {
-            predicate = builder.isTrue(root.get(EventCashFlowEntity_.portfolio).get(PortfolioEntity_.enabled));
+            Path<Object> path = root.get(EventCashFlowEntity_.portfolio)
+                    .get(PortfolioEntity_.ID);
+            return builder.equal(path, portfolio);
         }
-        return predicate;
+        Path<Boolean> path = root.get(EventCashFlowEntity_.portfolio)
+                .get(PortfolioEntity_.enabled);
+        return builder.isTrue(path);
+
     }
 
+    @Nullable
     private Predicate getDateFromPredicate(Root<EventCashFlowEntity> root, CriteriaBuilder builder) {
-        Predicate predicate = null;
-        if (dateFrom != null) {
-            predicate = builder.greaterThanOrEqualTo(
-                    root.get(EventCashFlowEntity_.timestamp),
-                    dateFrom.atStartOfDay(ZoneId.systemDefault()).toInstant()
-            );
+        if (dateFrom == null) {
+            return null;
         }
-        return predicate;
+        return builder.greaterThanOrEqualTo(
+                root.get(EventCashFlowEntity_.timestamp),
+                dateFrom.atStartOfDay(ZoneId.systemDefault()).toInstant());
     }
 
+    @Nullable
     private Predicate getDateToPredicate(Root<EventCashFlowEntity> root, CriteriaBuilder builder) {
-        Predicate predicate = null;
-        if (dateTo != null) {
-            predicate = builder.lessThanOrEqualTo(
-                    root.get(EventCashFlowEntity_.timestamp),
-                    dateTo.atStartOfDay(ZoneId.systemDefault()).toInstant()
-            );
+        if (dateTo == null) {
+            return null;
         }
-        return predicate;
+        return builder.lessThanOrEqualTo(
+                root.get(EventCashFlowEntity_.timestamp),
+                dateTo.atStartOfDay(ZoneId.systemDefault()).toInstant());
     }
 }

--- a/src/main/java/ru/investbook/repository/specs/EventCashFlowEntitySearchSpecification.java
+++ b/src/main/java/ru/investbook/repository/specs/EventCashFlowEntitySearchSpecification.java
@@ -19,7 +19,6 @@
 package ru.investbook.repository.specs;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.jpa.domain.Specification;
 import ru.investbook.entity.EventCashFlowEntity;
 import ru.investbook.entity.EventCashFlowEntity_;
@@ -29,11 +28,12 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Objects;
 import java.util.stream.Stream;
+
+import static org.springframework.util.StringUtils.hasText;
 
 
 @RequiredArgsConstructor(staticName = "of")
@@ -57,7 +57,7 @@ public class EventCashFlowEntitySearchSpecification implements Specification<Eve
 
     private Predicate getPortfolioPredicate(Root<EventCashFlowEntity> root, CriteriaBuilder builder) {
         Predicate predicate;
-        if (StringUtils.isNotBlank(portfolio)) {
+        if (hasText(portfolio)) {
             predicate = builder.equal(
                     root.get(EventCashFlowEntity_.portfolio).get(PortfolioEntity_.ID),
                     portfolio

--- a/src/main/java/ru/investbook/repository/specs/EventCashFlowEntitySearchSpecification.java
+++ b/src/main/java/ru/investbook/repository/specs/EventCashFlowEntitySearchSpecification.java
@@ -30,7 +30,9 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -72,9 +74,11 @@ public class EventCashFlowEntitySearchSpecification implements Specification<Eve
         if (dateFrom == null) {
             return null;
         }
+        Instant startOfDay = dateFrom.atStartOfDay(ZoneId.systemDefault())
+                .toInstant();
         return builder.greaterThanOrEqualTo(
                 root.get(EventCashFlowEntity_.timestamp),
-                dateFrom.atStartOfDay(ZoneId.systemDefault()).toInstant());
+                startOfDay);
     }
 
     @Nullable
@@ -82,8 +86,11 @@ public class EventCashFlowEntitySearchSpecification implements Specification<Eve
         if (dateTo == null) {
             return null;
         }
+        Instant endOfDay = dateTo.atTime(LocalTime.MAX)
+                .atZone(ZoneId.systemDefault())
+                .toInstant();
         return builder.lessThanOrEqualTo(
                 root.get(EventCashFlowEntity_.timestamp),
-                dateTo.atStartOfDay(ZoneId.systemDefault()).toInstant());
+                endOfDay);
     }
 }

--- a/src/main/java/ru/investbook/repository/specs/ForeignExchangeRateSearchSpecification.java
+++ b/src/main/java/ru/investbook/repository/specs/ForeignExchangeRateSearchSpecification.java
@@ -20,12 +20,14 @@ package ru.investbook.repository.specs;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.lang.Nullable;
 import ru.investbook.entity.ForeignExchangeRateEntity;
 import ru.investbook.entity.ForeignExchangeRateEntityPk_;
 import ru.investbook.entity.ForeignExchangeRateEntity_;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import java.time.LocalDate;
@@ -41,36 +43,32 @@ public class ForeignExchangeRateSearchSpecification implements Specification<For
     private final LocalDate date;
 
     @Override
-    public Predicate toPredicate(Root<ForeignExchangeRateEntity> root, CriteriaQuery<?> query,
-                                 CriteriaBuilder builder) {
+    public Predicate toPredicate(Root<ForeignExchangeRateEntity> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
         return Stream.of(
                         getCurrencyPredicate(root, builder),
-                        getDatePredicate(root, builder)
-                )
+                        getDatePredicate(root, builder))
                 .filter(Objects::nonNull)
                 .reduce(builder::and)
                 .orElseGet(builder::conjunction);
     }
 
+    @Nullable
     private Predicate getCurrencyPredicate(Root<ForeignExchangeRateEntity> root, CriteriaBuilder builder) {
-        Predicate predicate = null;
         if (hasText(currency)) {
-            predicate = builder.like(
-                    root.get(ForeignExchangeRateEntity_.pk).get(ForeignExchangeRateEntityPk_.CURRENCY_PAIR),
-                    currency + "%"
-            );
+            Path<String> path = root.get(ForeignExchangeRateEntity_.pk)
+                    .get(ForeignExchangeRateEntityPk_.CURRENCY_PAIR);
+            return builder.like(path, currency + "%");
         }
-        return predicate;
+        return null;
     }
 
+    @Nullable
     private Predicate getDatePredicate(Root<ForeignExchangeRateEntity> root, CriteriaBuilder builder) {
-        Predicate predicate = null;
-        if (date != null) {
-            predicate = builder.equal(
-                    root.get(ForeignExchangeRateEntity_.pk).get(ForeignExchangeRateEntityPk_.DATE),
-                    date
-            );
+        if (date == null) {
+            return null;
         }
-        return predicate;
+        Path<Object> path = root.get(ForeignExchangeRateEntity_.pk)
+                .get(ForeignExchangeRateEntityPk_.DATE);
+        return builder.equal(path, date);
     }
 }

--- a/src/main/java/ru/investbook/repository/specs/ForeignExchangeRateSearchSpecification.java
+++ b/src/main/java/ru/investbook/repository/specs/ForeignExchangeRateSearchSpecification.java
@@ -19,7 +19,6 @@
 package ru.investbook.repository.specs;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.jpa.domain.Specification;
 import ru.investbook.entity.ForeignExchangeRateEntity;
 import ru.investbook.entity.ForeignExchangeRateEntityPk_;
@@ -32,6 +31,8 @@ import javax.persistence.criteria.Root;
 import java.time.LocalDate;
 import java.util.Objects;
 import java.util.stream.Stream;
+
+import static org.springframework.util.StringUtils.hasText;
 
 
 @RequiredArgsConstructor(staticName = "of")
@@ -53,7 +54,7 @@ public class ForeignExchangeRateSearchSpecification implements Specification<For
 
     private Predicate getCurrencyPredicate(Root<ForeignExchangeRateEntity> root, CriteriaBuilder builder) {
         Predicate predicate = null;
-        if (StringUtils.isNotBlank(currency)) {
+        if (hasText(currency)) {
             predicate = builder.like(
                     root.get(ForeignExchangeRateEntity_.pk).get(ForeignExchangeRateEntityPk_.CURRENCY_PAIR),
                     currency + "%"

--- a/src/main/java/ru/investbook/repository/specs/SecurityEventCashFlowEntitySearchSpecification.java
+++ b/src/main/java/ru/investbook/repository/specs/SecurityEventCashFlowEntitySearchSpecification.java
@@ -19,7 +19,6 @@
 package ru.investbook.repository.specs;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 import org.spacious_team.broker.pojo.CashFlowType;
 import org.springframework.data.jpa.domain.Specification;
 import ru.investbook.entity.CashFlowTypeEntity_;
@@ -37,7 +36,7 @@ import java.time.ZoneId;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.springframework.util.StringUtils.hasText;
 
 
 @RequiredArgsConstructor(staticName = "of")
@@ -64,7 +63,7 @@ public class SecurityEventCashFlowEntitySearchSpecification implements Specifica
 
     private Predicate getPortfolioPredicate(Root<SecurityEventCashFlowEntity> root, CriteriaBuilder builder) {
         Predicate predicate;
-        if (StringUtils.isNotBlank(portfolio)) {
+        if (hasText(portfolio)) {
             predicate = builder.equal(
                     root.get(SecurityEventCashFlowEntity_.portfolio).get(PortfolioEntity_.ID),
                     portfolio
@@ -99,7 +98,7 @@ public class SecurityEventCashFlowEntitySearchSpecification implements Specifica
 
     private Predicate getSecurityPredicate(Root<SecurityEventCashFlowEntity> root, CriteriaBuilder builder) {
         Predicate predicate = null;
-        if (isNotBlank(security)) {
+        if (hasText(security)) {
             predicate= builder.or(
                     builder.equal(root.get(SecurityEventCashFlowEntity_.security).get(SecurityEntity_.ticker), security),
                     builder.equal(root.get(SecurityEventCashFlowEntity_.security).get(SecurityEntity_.isin), security),

--- a/src/main/java/ru/investbook/repository/specs/SecurityEventCashFlowEntitySearchSpecification.java
+++ b/src/main/java/ru/investbook/repository/specs/SecurityEventCashFlowEntitySearchSpecification.java
@@ -33,7 +33,9 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -80,9 +82,11 @@ public class SecurityEventCashFlowEntitySearchSpecification implements Specifica
         if (dateFrom == null) {
             return null;
         }
+        Instant startOfDay = dateFrom.atStartOfDay(ZoneId.systemDefault())
+                .toInstant();
         return builder.greaterThanOrEqualTo(
                 root.get(SecurityEventCashFlowEntity_.timestamp),
-                dateFrom.atStartOfDay(ZoneId.systemDefault()).toInstant());
+                startOfDay);
     }
 
     @Nullable
@@ -90,9 +94,12 @@ public class SecurityEventCashFlowEntitySearchSpecification implements Specifica
         if (dateTo == null) {
             return null;
         }
+        Instant endOfDay = dateTo.atTime(LocalTime.MAX)
+                .atZone(ZoneId.systemDefault())
+                .toInstant();
         return builder.lessThanOrEqualTo(
                 root.get(SecurityEventCashFlowEntity_.timestamp),
-                dateTo.atStartOfDay(ZoneId.systemDefault()).toInstant());
+                endOfDay);
     }
 
     @Nullable

--- a/src/main/java/ru/investbook/repository/specs/SecurityQuoteSearchSpecification.java
+++ b/src/main/java/ru/investbook/repository/specs/SecurityQuoteSearchSpecification.java
@@ -19,7 +19,6 @@
 package ru.investbook.repository.specs;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.jpa.domain.Specification;
 import ru.investbook.entity.SecurityEntity_;
 import ru.investbook.entity.SecurityQuoteEntity;
@@ -34,7 +33,7 @@ import java.time.ZoneId;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.springframework.util.StringUtils.hasText;
 
 
 @RequiredArgsConstructor(staticName = "of")
@@ -57,7 +56,7 @@ public class SecurityQuoteSearchSpecification implements Specification<SecurityQ
 
     private Predicate getCurrencyPredicate(Root<SecurityQuoteEntity> root, CriteriaBuilder builder) {
         Predicate predicate = null;
-        if (StringUtils.isNotBlank(currency)) {
+        if (hasText(currency)) {
             predicate = builder.equal(
                     root.get(SecurityQuoteEntity_.currency),
                     currency
@@ -80,7 +79,7 @@ public class SecurityQuoteSearchSpecification implements Specification<SecurityQ
 
     private Predicate getSecurityPredicate(Root<SecurityQuoteEntity> root, CriteriaBuilder builder) {
         Predicate predicate = null;
-        if (isNotBlank(security)) {
+        if (hasText(security)) {
             predicate= builder.or(
                     builder.equal(root.get(SecurityQuoteEntity_.security).get(SecurityEntity_.ticker), security),
                     builder.equal(root.get(SecurityQuoteEntity_.security).get(SecurityEntity_.isin), security),

--- a/src/main/java/ru/investbook/repository/specs/SecurityQuoteSearchSpecification.java
+++ b/src/main/java/ru/investbook/repository/specs/SecurityQuoteSearchSpecification.java
@@ -30,7 +30,9 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -70,10 +72,15 @@ public class SecurityQuoteSearchSpecification implements Specification<SecurityQ
         if (date == null) {
             return null;
         }
+        Instant startOfDay = date.atStartOfDay(ZoneId.systemDefault())
+                .toInstant();
+        Instant endOfDay = date.atTime(LocalTime.MAX)
+               .atZone(ZoneId.systemDefault())
+                .toInstant();
         return builder.between(
                 root.get(SecurityQuoteEntity_.timestamp),
-                date.atStartOfDay(ZoneId.systemDefault()).toInstant(),
-                date.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
+                startOfDay,
+                endOfDay);
     }
 
     @Nullable

--- a/src/main/java/ru/investbook/repository/specs/SpecificationHelper.java
+++ b/src/main/java/ru/investbook/repository/specs/SpecificationHelper.java
@@ -1,0 +1,40 @@
+/*
+ * InvestBook
+ * Copyright (C) 2022  Spacious Team <spacious-team@ya.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ru.investbook.repository.specs;
+
+import lombok.NoArgsConstructor;
+import ru.investbook.entity.SecurityEntity;
+import ru.investbook.entity.SecurityEntity_;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+class SpecificationHelper {
+
+    static Predicate filterSecurity(CriteriaBuilder builder, Path<SecurityEntity> security, String searchingSecurity) {
+        return builder.or(
+                builder.equal(security.get(SecurityEntity_.ticker), searchingSecurity),
+                builder.equal(security.get(SecurityEntity_.isin), searchingSecurity),
+                builder.like(security.get(SecurityEntity_.name), searchingSecurity + "%"));
+    }
+}

--- a/src/main/java/ru/investbook/repository/specs/TransactionSearchSpecification.java
+++ b/src/main/java/ru/investbook/repository/specs/TransactionSearchSpecification.java
@@ -33,7 +33,9 @@ import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Subquery;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -88,9 +90,11 @@ public class TransactionSearchSpecification implements Specification<Transaction
         if (dateFrom == null) {
             return null;
         }
+        Instant startOfDay = dateFrom.atStartOfDay(ZoneId.systemDefault())
+                .toInstant();
         return builder.greaterThanOrEqualTo(
                 root.get(TransactionEntity_.timestamp),
-                dateFrom.atStartOfDay(ZoneId.systemDefault()).toInstant());
+                startOfDay);
     }
 
     @Nullable
@@ -98,9 +102,12 @@ public class TransactionSearchSpecification implements Specification<Transaction
         if (dateTo == null) {
             return null;
         }
+        Instant endOfDay = dateTo.atTime(LocalTime.MAX)
+                .atZone(ZoneId.systemDefault())
+                .toInstant();
         return builder.lessThanOrEqualTo(
                 root.get(TransactionEntity_.timestamp),
-                dateTo.atStartOfDay(ZoneId.systemDefault()).toInstant());
+                endOfDay);
     }
 
     @Nullable

--- a/src/main/java/ru/investbook/repository/specs/TransactionSearchSpecification.java
+++ b/src/main/java/ru/investbook/repository/specs/TransactionSearchSpecification.java
@@ -30,6 +30,7 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Subquery;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Objects;
@@ -69,8 +70,8 @@ public class TransactionSearchSpecification implements Specification<Transaction
         } else {
             //We do subquery because TransactionEntity is not related to PortfolioEntity in Java model, so
             //we can not do join query in Criteria API
-            var activePortfoliosSubquery = query.subquery(String.class);
-            var activePortfoliosRoot = activePortfoliosSubquery.from(PortfolioEntity.class);
+            Subquery<String> activePortfoliosSubquery = query.subquery(String.class);
+            Root<PortfolioEntity> activePortfoliosRoot = activePortfoliosSubquery.from(PortfolioEntity.class);
 
             predicate = builder.in(root.get(TransactionEntity_.portfolio)).value(
                     activePortfoliosSubquery

--- a/src/main/java/ru/investbook/repository/specs/TransactionSearchSpecification.java
+++ b/src/main/java/ru/investbook/repository/specs/TransactionSearchSpecification.java
@@ -36,7 +36,7 @@ import java.time.ZoneId;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.springframework.util.StringUtils.hasText;
 
 
 @RequiredArgsConstructor(staticName = "of")
@@ -62,7 +62,7 @@ public class TransactionSearchSpecification implements Specification<Transaction
     private Predicate getPortfolioPredicate(Root<TransactionEntity> root, CriteriaQuery<?> query,
                                             CriteriaBuilder builder) {
         Predicate predicate;
-        if (isNotBlank(portfolio)) {
+        if (hasText(portfolio)) {
             predicate = builder.equal(
                     root.get(TransactionEntity_.portfolio),
                     portfolio
@@ -106,7 +106,7 @@ public class TransactionSearchSpecification implements Specification<Transaction
 
     private Predicate getSecurityPredicate(Root<TransactionEntity> root, CriteriaBuilder builder) {
         Predicate predicate = null;
-        if (isNotBlank(security)) {
+        if (hasText(security)) {
             predicate= builder.or(
                     builder.equal(root.get(TransactionEntity_.security).get(SecurityEntity_.ticker), security),
                     builder.equal(root.get(TransactionEntity_.security).get(SecurityEntity_.isin), security),

--- a/src/main/java/ru/investbook/web/forms/controller/EventCashFlowController.java
+++ b/src/main/java/ru/investbook/web/forms/controller/EventCashFlowController.java
@@ -19,6 +19,7 @@
 package ru.investbook.web.forms.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -58,7 +59,7 @@ public class EventCashFlowController {
 
     @GetMapping
     public String get(@ModelAttribute("filter") EventCashFlowFormFilterModel filter, Model model) {
-        var data = eventCashFlowFormsService.getPage(filter);
+        Page<EventCashFlowModel> data = eventCashFlowFormsService.getPage(filter);
         model.addAttribute("page", new PageableWrapperModel<>(data));
         model.addAttribute("portfolios", portfolios);
 

--- a/src/main/java/ru/investbook/web/forms/controller/ForeignExchangeRateController.java
+++ b/src/main/java/ru/investbook/web/forms/controller/ForeignExchangeRateController.java
@@ -19,6 +19,7 @@
 package ru.investbook.web.forms.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -34,7 +35,6 @@ import ru.investbook.repository.TransactionRepository;
 import ru.investbook.service.cbr.CbrForeignExchangeRateService;
 import ru.investbook.web.forms.model.ForeignExchangeRateModel;
 import ru.investbook.web.forms.model.PageableWrapperModel;
-import ru.investbook.web.forms.model.filter.EventCashFlowFormFilterModel;
 import ru.investbook.web.forms.model.filter.ForeignExchangeRateFormFilterModel;
 import ru.investbook.web.forms.service.ForeignExchangeRateFormsService;
 
@@ -54,7 +54,7 @@ public class ForeignExchangeRateController {
 
     @GetMapping
     public String get(@ModelAttribute("filter") ForeignExchangeRateFormFilterModel filter, Model model) {
-        var data = foreignExchangeRateFormsService.getPage(filter);
+        Page<ForeignExchangeRateModel> data = foreignExchangeRateFormsService.getPage(filter);
         model.addAttribute("page", new PageableWrapperModel<>(data));
 
         return "foreign-exchange-rates/table";

--- a/src/main/java/ru/investbook/web/forms/controller/PortfolioController.java
+++ b/src/main/java/ru/investbook/web/forms/controller/PortfolioController.java
@@ -58,7 +58,7 @@ public class PortfolioController {
     public String postEventCashFlow(@Valid @ModelAttribute("archive") ArchivedPortfolioModel archive) {
         getPortfolios(portfolioRepository)
                 .forEach(portfolio -> {
-                    var isEnabled = !archive.getPortfolios().contains(portfolio);
+                    boolean isEnabled = !archive.getPortfolios().contains(portfolio);
                     portfolioRepository.setEnabledForPortfolio(portfolio, isEnabled);
                 });
         return "success";

--- a/src/main/java/ru/investbook/web/forms/controller/SecurityDepositController.java
+++ b/src/main/java/ru/investbook/web/forms/controller/SecurityDepositController.java
@@ -37,6 +37,7 @@ import ru.investbook.web.forms.model.filter.TransactionFormFilterModel;
 import ru.investbook.web.forms.service.TransactionFormsService;
 
 import javax.validation.Valid;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Controller
@@ -51,7 +52,7 @@ public class SecurityDepositController extends TransactionController {
 
     @GetMapping
     public String get(@ModelAttribute("filter") TransactionFormFilterModel filter, Model model) {
-        var data = transactionFormsService.getAll(filter)
+        List<TransactionModel> data = transactionFormsService.getAll(filter)
                 .stream()
                 .filter(tr -> tr.getPrice() == null)
                 .collect(Collectors.toList());

--- a/src/main/java/ru/investbook/web/forms/controller/SecurityEventCashFlowController.java
+++ b/src/main/java/ru/investbook/web/forms/controller/SecurityEventCashFlowController.java
@@ -19,6 +19,7 @@
 package ru.investbook.web.forms.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -60,7 +61,7 @@ public class SecurityEventCashFlowController {
 
     @GetMapping
     public String get(@ModelAttribute("filter") SecurityEventCashFlowFormFilterModel filter, Model model) {
-        var data = securityEventCashFlowFormsService.getPage(filter);
+        Page<SecurityEventCashFlowModel> data = securityEventCashFlowFormsService.getPage(filter);
         model.addAttribute("page", new PageableWrapperModel<>(data));
         model.addAttribute("portfolios", portfolios);
 

--- a/src/main/java/ru/investbook/web/forms/controller/SecurityQuoteController.java
+++ b/src/main/java/ru/investbook/web/forms/controller/SecurityQuoteController.java
@@ -20,6 +20,7 @@ package ru.investbook.web.forms.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -66,7 +67,7 @@ public class SecurityQuoteController {
 
     @GetMapping
     public String get(@ModelAttribute("filter") SecurityQuoteFormFilterModel filter, Model model) {
-        var data = securityQuoteFormsService.getPage(filter);
+        Page<SecurityQuoteModel> data = securityQuoteFormsService.getPage(filter);
         model.addAttribute("page", new PageableWrapperModel<>(data));
 
         return "security-quotes/table";

--- a/src/main/java/ru/investbook/web/forms/controller/TransactionController.java
+++ b/src/main/java/ru/investbook/web/forms/controller/TransactionController.java
@@ -19,6 +19,7 @@
 package ru.investbook.web.forms.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -60,7 +61,7 @@ public class TransactionController {
 
     @GetMapping
     public String get(@ModelAttribute("filter") TransactionFormFilterModel filter, Model model) {
-        var data = transactionFormsService.getPage(filter);
+        Page<TransactionModel> data = transactionFormsService.getPage(filter);
         model.addAttribute("page", new PageableWrapperModel<>(data));
         model.addAttribute("portfolios", portfolios);
 

--- a/src/main/java/ru/investbook/web/forms/model/EventCashFlowModel.java
+++ b/src/main/java/ru/investbook/web/forms/model/EventCashFlowModel.java
@@ -81,7 +81,7 @@ public class EventCashFlowModel {
         return switch (type) {
             case DIVIDEND, COUPON, REDEMPTION, AMORTIZATION, ACCRUED_INTEREST -> type.name();
             case CASH -> {
-                var desc = String.valueOf(description).toLowerCase();
+                String desc = String.valueOf(description).toLowerCase();
                 if (desc.contains("вычет") && desc.contains("иис")) {
                     yield "TAX_IIS_A";
                 }

--- a/src/main/java/ru/investbook/web/forms/model/filter/AbstractFormFilterModel.java
+++ b/src/main/java/ru/investbook/web/forms/model/filter/AbstractFormFilterModel.java
@@ -16,14 +16,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package ru.investbook.web.forms.model;
+package ru.investbook.web.forms.model.filter;
 
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-public abstract class AbstractFormFilterModel {
-    private Integer pageSize = 20;
+abstract class AbstractFormFilterModel {
+    private Integer pageSize = 10;
     private Integer page = 0;
 }

--- a/src/main/java/ru/investbook/web/forms/model/filter/EventCashFlowFormFilterModel.java
+++ b/src/main/java/ru/investbook/web/forms/model/filter/EventCashFlowFormFilterModel.java
@@ -21,7 +21,6 @@ package ru.investbook.web.forms.model.filter;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
-import ru.investbook.web.forms.model.AbstractFormFilterModel;
 
 import java.time.LocalDate;
 

--- a/src/main/java/ru/investbook/web/forms/model/filter/ForeignExchangeRateFormFilterModel.java
+++ b/src/main/java/ru/investbook/web/forms/model/filter/ForeignExchangeRateFormFilterModel.java
@@ -21,7 +21,6 @@ package ru.investbook.web.forms.model.filter;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
-import ru.investbook.web.forms.model.AbstractFormFilterModel;
 
 import java.time.LocalDate;
 

--- a/src/main/java/ru/investbook/web/forms/model/filter/SecurityEventCashFlowFormFilterModel.java
+++ b/src/main/java/ru/investbook/web/forms/model/filter/SecurityEventCashFlowFormFilterModel.java
@@ -21,7 +21,6 @@ package ru.investbook.web.forms.model.filter;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
-import ru.investbook.web.forms.model.AbstractFormFilterModel;
 
 import java.time.LocalDate;
 

--- a/src/main/java/ru/investbook/web/forms/model/filter/SecurityQuoteFormFilterModel.java
+++ b/src/main/java/ru/investbook/web/forms/model/filter/SecurityQuoteFormFilterModel.java
@@ -21,7 +21,6 @@ package ru.investbook.web.forms.model.filter;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
-import ru.investbook.web.forms.model.AbstractFormFilterModel;
 
 import java.time.LocalDate;
 

--- a/src/main/java/ru/investbook/web/forms/model/filter/TransactionFormFilterModel.java
+++ b/src/main/java/ru/investbook/web/forms/model/filter/TransactionFormFilterModel.java
@@ -21,7 +21,6 @@ package ru.investbook.web.forms.model.filter;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
-import ru.investbook.web.forms.model.AbstractFormFilterModel;
 
 import java.time.LocalDate;
 

--- a/src/main/java/ru/investbook/web/forms/service/EventCashFlowFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/EventCashFlowFormsService.java
@@ -68,10 +68,10 @@ public class EventCashFlowFormsService {
 
     @Transactional(readOnly = true)
     public Page<EventCashFlowModel> getPage(EventCashFlowFormFilterModel filter) {
-        var spec = EventCashFlowEntitySearchSpecification.of(
+        EventCashFlowEntitySearchSpecification spec = EventCashFlowEntitySearchSpecification.of(
                 filter.getPortfolio(), filter.getDateFrom(), filter.getDateTo()
         );
-        var page = PageRequest.of(
+        PageRequest page = PageRequest.of(
                 filter.getPage(), filter.getPageSize(), Sort.by(Order.asc("portfolio.id"), Order.desc("timestamp"))
         );
 

--- a/src/main/java/ru/investbook/web/forms/service/EventCashFlowFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/EventCashFlowFormsService.java
@@ -69,13 +69,13 @@ public class EventCashFlowFormsService {
     @Transactional(readOnly = true)
     public Page<EventCashFlowModel> getPage(EventCashFlowFormFilterModel filter) {
         EventCashFlowEntitySearchSpecification spec = EventCashFlowEntitySearchSpecification.of(
-                filter.getPortfolio(), filter.getDateFrom(), filter.getDateTo()
-        );
-        PageRequest page = PageRequest.of(
-                filter.getPage(), filter.getPageSize(), Sort.by(Order.asc("portfolio.id"), Order.desc("timestamp"))
-        );
+                filter.getPortfolio(), filter.getDateFrom(), filter.getDateTo());
 
-        return eventCashFlowRepository.findAll(spec, page).map(this::toModel);
+        Sort sort = Sort.by(Order.asc("portfolio.id"), Order.desc("timestamp"));
+        PageRequest page = PageRequest.of(filter.getPage(), filter.getPageSize(), sort);
+
+        return eventCashFlowRepository.findAll(spec, page)
+                .map(this::toModel);
     }
 
     @Transactional

--- a/src/main/java/ru/investbook/web/forms/service/ForeignExchangeRateFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/ForeignExchangeRateFormsService.java
@@ -57,11 +57,11 @@ public class ForeignExchangeRateFormsService {
 
     @Transactional(readOnly = true)
     public Page<ForeignExchangeRateModel> getPage(ForeignExchangeRateFormFilterModel filter) {
-        var spec = ForeignExchangeRateSearchSpecification.of(
+        ForeignExchangeRateSearchSpecification spec = ForeignExchangeRateSearchSpecification.of(
                 filter.getCurrency(), filter.getDate()
         );
 
-        var page = PageRequest.of(
+        PageRequest page = PageRequest.of(
                 filter.getPage(), filter.getPageSize(), Sort.by(desc("pk.date"), asc("pk.currencyPair"))
         );
 

--- a/src/main/java/ru/investbook/web/forms/service/ForeignExchangeRateFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/ForeignExchangeRateFormsService.java
@@ -57,15 +57,14 @@ public class ForeignExchangeRateFormsService {
 
     @Transactional(readOnly = true)
     public Page<ForeignExchangeRateModel> getPage(ForeignExchangeRateFormFilterModel filter) {
-        ForeignExchangeRateSearchSpecification spec = ForeignExchangeRateSearchSpecification.of(
-                filter.getCurrency(), filter.getDate()
-        );
+        ForeignExchangeRateSearchSpecification spec =
+                ForeignExchangeRateSearchSpecification.of(filter.getCurrency(), filter.getDate());
 
-        PageRequest page = PageRequest.of(
-                filter.getPage(), filter.getPageSize(), Sort.by(desc("pk.date"), asc("pk.currencyPair"))
-        );
+        Sort sort = Sort.by(desc("pk.date"), asc("pk.currencyPair"));
+        PageRequest page = PageRequest.of(filter.getPage(), filter.getPageSize(), sort);
 
-        return foreignExchangeRateRepository.findAll(spec, page).map(this::toModel);
+        return foreignExchangeRateRepository.findAll(spec, page)
+                .map(this::toModel);
     }
 
     @Transactional

--- a/src/main/java/ru/investbook/web/forms/service/PortfolioCashFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/PortfolioCashFormsService.java
@@ -38,7 +38,6 @@ import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -65,7 +64,7 @@ public class PortfolioCashFormsService {
         return portfolioCashRepository.findByPortfolioInOrderByTimestampDesc(enabledPortfolios)
                 .stream()
                 .map(this::toModel)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/ru/investbook/web/forms/service/PortfolioPropertyFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/PortfolioPropertyFormsService.java
@@ -40,7 +40,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.spacious_team.broker.pojo.PortfolioPropertyType.*;
 
@@ -69,7 +68,7 @@ public class PortfolioPropertyFormsService {
                         properties)
                 .stream()
                 .map(this::toModel)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/ru/investbook/web/forms/service/SecurityDescriptionFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/SecurityDescriptionFormsService.java
@@ -30,7 +30,6 @@ import ru.investbook.web.forms.model.SecurityType;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
 
@@ -53,7 +52,7 @@ public class SecurityDescriptionFormsService {
         return securityDescriptionRepository.findAll()
                 .stream()
                 .map(this::toModel)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/ru/investbook/web/forms/service/SecurityEventCashFlowFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/SecurityEventCashFlowFormsService.java
@@ -65,15 +65,15 @@ public class SecurityEventCashFlowFormsService {
 
     @Transactional(readOnly = true)
     public Page<SecurityEventCashFlowModel> getPage(SecurityEventCashFlowFormFilterModel filter) {
-        SecurityEventCashFlowEntitySearchSpecification spec = SecurityEventCashFlowEntitySearchSpecification.of(
-                filter.getPortfolio(), filter.getSecurity(), filter.getDateFrom(), filter.getDateTo()
-        );
-        PageRequest page = PageRequest.of(
-                filter.getPage(), filter.getPageSize(),
-                Sort.by(asc("portfolio.id"), desc("timestamp"), asc("security.id"))
-        );
+        SecurityEventCashFlowEntitySearchSpecification spec =
+                SecurityEventCashFlowEntitySearchSpecification.of(
+                        filter.getPortfolio(), filter.getSecurity(), filter.getDateFrom(), filter.getDateTo());
 
-        return securityEventCashFlowRepository.findAll(spec, page).map(this::toSecurityEventModel);
+        Sort sort = Sort.by(asc("portfolio.id"), desc("timestamp"), asc("security.id"));
+        PageRequest page = PageRequest.of(filter.getPage(), filter.getPageSize(), sort);
+
+        return securityEventCashFlowRepository.findAll(spec, page)
+                .map(this::toSecurityEventModel);
     }
 
     @Transactional
@@ -132,16 +132,16 @@ public class SecurityEventCashFlowFormsService {
                 securityEntity.getIsin(),
                 ofNullable(securityEntity.getName()).orElse(securityEntity.getTicker()),
                 m.getSecurityType());
-        m.setValue(type == DERIVATIVE_PROFIT ? e.getValue() :  e.getValue().abs());
+        m.setValue(type == DERIVATIVE_PROFIT ? e.getValue() : e.getValue().abs());
         m.setValueCurrency(e.getCurrency());
 
         if (m.getType() != CashFlowType.TAX) {
             securityEventCashFlowRepository.findByPortfolioIdAndSecurityIdAndCashFlowTypeIdAndTimestampAndCount(
-                    m.getPortfolio(),
-                    securityEntity.getId(),
-                    CashFlowType.TAX.getId(),
-                    e.getTimestamp(),
-                    m.getCount())
+                            m.getPortfolio(),
+                            securityEntity.getId(),
+                            CashFlowType.TAX.getId(),
+                            e.getTimestamp(),
+                            m.getCount())
                     .ifPresent(tax -> {
                         m.setTaxId(tax.getId());
                         m.setTax(tax.getValue().abs());

--- a/src/main/java/ru/investbook/web/forms/service/SecurityEventCashFlowFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/SecurityEventCashFlowFormsService.java
@@ -65,10 +65,10 @@ public class SecurityEventCashFlowFormsService {
 
     @Transactional(readOnly = true)
     public Page<SecurityEventCashFlowModel> getPage(SecurityEventCashFlowFormFilterModel filter) {
-        var spec = SecurityEventCashFlowEntitySearchSpecification.of(
+        SecurityEventCashFlowEntitySearchSpecification spec = SecurityEventCashFlowEntitySearchSpecification.of(
                 filter.getPortfolio(), filter.getSecurity(), filter.getDateFrom(), filter.getDateTo()
         );
-        var page = PageRequest.of(
+        PageRequest page = PageRequest.of(
                 filter.getPage(), filter.getPageSize(),
                 Sort.by(asc("portfolio.id"), desc("timestamp"), asc("security.id"))
         );

--- a/src/main/java/ru/investbook/web/forms/service/SecurityQuoteFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/SecurityQuoteFormsService.java
@@ -57,13 +57,13 @@ public class SecurityQuoteFormsService {
     @Transactional(readOnly = true)
     public Page<SecurityQuoteModel> getPage(SecurityQuoteFormFilterModel filter) {
         SecurityQuoteSearchSpecification spec = SecurityQuoteSearchSpecification.of(
-                filter.getSecurity(), filter.getCurrency(), filter.getDate()
-        );
-        PageRequest page = PageRequest.of(
-                filter.getPage(), filter.getPageSize(), Sort.by(desc("timestamp"), asc("security.name"))
-        );
+                filter.getSecurity(), filter.getCurrency(), filter.getDate());
 
-        return securityQuoteRepository.findAll(spec, page).map(this::toSecurityQuoteModel);
+        Sort sort = Sort.by(desc("timestamp"), asc("security.name"));
+        PageRequest page = PageRequest.of(filter.getPage(), filter.getPageSize(), sort);
+
+        return securityQuoteRepository.findAll(spec, page)
+                .map(this::toSecurityQuoteModel);
     }
 
     @Transactional

--- a/src/main/java/ru/investbook/web/forms/service/SecurityQuoteFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/SecurityQuoteFormsService.java
@@ -56,10 +56,10 @@ public class SecurityQuoteFormsService {
 
     @Transactional(readOnly = true)
     public Page<SecurityQuoteModel> getPage(SecurityQuoteFormFilterModel filter) {
-        var spec = SecurityQuoteSearchSpecification.of(
+        SecurityQuoteSearchSpecification spec = SecurityQuoteSearchSpecification.of(
                 filter.getSecurity(), filter.getCurrency(), filter.getDate()
         );
-        var page = PageRequest.of(
+        PageRequest page = PageRequest.of(
                 filter.getPage(), filter.getPageSize(), Sort.by(desc("timestamp"), asc("security.name"))
         );
 

--- a/src/main/java/ru/investbook/web/forms/service/TransactionFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/TransactionFormsService.java
@@ -98,7 +98,8 @@ public class TransactionFormsService {
         Sort sort = Sort.by(asc("portfolio"), desc("timestamp"), asc("security.id"));
         PageRequest page = PageRequest.of(filter.getPage(), filter.getPageSize(), sort);
 
-        return transactionRepository.findAll(spec, page).map(this::toTransactionModel);
+        return transactionRepository.findAll(spec, page)
+                .map(this::toTransactionModel);
     }
 
     @Transactional(readOnly = true)
@@ -106,7 +107,10 @@ public class TransactionFormsService {
         TransactionSearchSpecification spec = TransactionSearchSpecification.of(
                 filter.getPortfolio(), filter.getSecurity(), filter.getDateFrom(), filter.getDateTo());
 
-        return transactionRepository.findAll(spec).stream()
+        Sort sort = Sort.by(asc("portfolio"), desc("timestamp"), asc("security.id"));
+
+        return transactionRepository.findAll(spec, sort)
+                .stream()
                 .map(this::toTransactionModel)
                 .toList();
     }

--- a/src/main/java/ru/investbook/web/forms/service/TransactionFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/TransactionFormsService.java
@@ -59,7 +59,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import static java.lang.Math.abs;
 import static java.util.Optional.ofNullable;
@@ -94,13 +93,10 @@ public class TransactionFormsService {
     @Transactional(readOnly = true)
     public Page<TransactionModel> getPage(TransactionFormFilterModel filter) {
         TransactionSearchSpecification spec = TransactionSearchSpecification.of(
-                filter.getPortfolio(), filter.getSecurity(), filter.getDateFrom(), filter.getDateTo()
-        );
+                filter.getPortfolio(), filter.getSecurity(), filter.getDateFrom(), filter.getDateTo());
 
-        PageRequest page = PageRequest.of(
-                filter.getPage(), filter.getPageSize(),
-                Sort.by(asc("portfolio"), desc("timestamp"), asc("security.id"))
-        );
+        Sort sort = Sort.by(asc("portfolio"), desc("timestamp"), asc("security.id"));
+        PageRequest page = PageRequest.of(filter.getPage(), filter.getPageSize(), sort);
 
         return transactionRepository.findAll(spec, page).map(this::toTransactionModel);
     }
@@ -108,12 +104,11 @@ public class TransactionFormsService {
     @Transactional(readOnly = true)
     public List<TransactionModel> getAll(TransactionFormFilterModel filter) {
         TransactionSearchSpecification spec = TransactionSearchSpecification.of(
-                filter.getPortfolio(), filter.getSecurity(), filter.getDateFrom(), filter.getDateTo()
-        );
+                filter.getPortfolio(), filter.getSecurity(), filter.getDateFrom(), filter.getDateTo());
 
         return transactionRepository.findAll(spec).stream()
                 .map(this::toTransactionModel)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/ru/investbook/web/forms/service/TransactionFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/TransactionFormsService.java
@@ -35,7 +35,6 @@ import org.springframework.util.Assert;
 import ru.investbook.converter.PortfolioConverter;
 import ru.investbook.converter.TransactionCashFlowConverter;
 import ru.investbook.converter.TransactionConverter;
-import ru.investbook.entity.PortfolioEntity;
 import ru.investbook.entity.SecurityEntity;
 import ru.investbook.entity.TransactionCashFlowEntity;
 import ru.investbook.entity.TransactionEntity;
@@ -94,11 +93,11 @@ public class TransactionFormsService {
 
     @Transactional(readOnly = true)
     public Page<TransactionModel> getPage(TransactionFormFilterModel filter) {
-        var spec = TransactionSearchSpecification.of(
+        TransactionSearchSpecification spec = TransactionSearchSpecification.of(
                 filter.getPortfolio(), filter.getSecurity(), filter.getDateFrom(), filter.getDateTo()
         );
 
-        var page = PageRequest.of(
+        PageRequest page = PageRequest.of(
                 filter.getPage(), filter.getPageSize(),
                 Sort.by(asc("portfolio"), desc("timestamp"), asc("security.id"))
         );
@@ -108,7 +107,7 @@ public class TransactionFormsService {
 
     @Transactional(readOnly = true)
     public List<TransactionModel> getAll(TransactionFormFilterModel filter) {
-        var spec = TransactionSearchSpecification.of(
+        TransactionSearchSpecification spec = TransactionSearchSpecification.of(
                 filter.getPortfolio(), filter.getSecurity(), filter.getDateFrom(), filter.getDateTo()
         );
 

--- a/src/main/resources/static/water-wrapper.css
+++ b/src/main/resources/static/water-wrapper.css
@@ -40,7 +40,7 @@ input {
 }
 
 input[type=date] {
-    width:130px;
+    width: 130px;
 }
 
 input[type=submit] {
@@ -82,27 +82,50 @@ tr:hover > .table-row-control {
     opacity: 1;
 }
 
+.search-filter {
+    display: flex;
+    justify-content: center;
+    color: dimgray;
+}
+
+.search-filter * {
+    color: dimgray;
+}
+
+.search-filter input[type=date] {
+    width: 112px;
+}
+
+.search-filter .currency {
+    width: 76px;
+}
+
+.search-filter .page-size {
+    width: 6em;
+}
+
 .page-bar {
     display: flex;
     align-items: center;
     justify-content: center;
     list-style-type: none;
-    padding: 0px;
+    padding: 0;
 }
 
-.page-item {
+.page-bar li * {
     margin: 0 10px;
 }
 
-.page-disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-  text-decoration: none;
-  pointer-events: none;
+.page-bar .page-disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    text-decoration: none;
+    pointer-events: none;
 }
 
-.page-active, .page-active a {
-  cursor: not-allowed;
-  pointer-events: none;
-  text-decoration: underline;
+.page-bar .page-active a {
+    cursor: not-allowed;
+    pointer-events: none;
+    text-decoration: underline;
+    font-weight: bold;
 }

--- a/src/main/resources/templates/events/table.html
+++ b/src/main/resources/templates/events/table.html
@@ -53,14 +53,8 @@
                 <option th:each="portfolio : ${portfolios}" th:text="${portfolio}" th:value="${portfolio}"/>
             </select>
         </label>
-        <label>
-            Дата
-            <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"/>
-        </label>
-        <label>
-            Размер страницы
-            <div th:replace="fragments/search :: page-size ('*{pageSize}')"/>
-        </label>
+        <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"/>
+        <div th:replace="fragments/search :: page-size ('*{pageSize}')"/>
     </div>
     <input type="submit" value="Поиск"/>
 </form>
@@ -103,10 +97,10 @@
 
     <div th:insert="fragments/navigation :: navigation-bar (
         endpoint='events',
-        params='portfolio=__${filter.portfolio}__,
-                dateFrom=__${filter.dateFrom}__,
-                dateTo=__${filter.dateTo}__,
-                pageSize=__${filter.pageSize}__'
+        params='portfolio=${filter.portfolio},
+                dateFrom=${filter.dateFrom},
+                dateTo=${filter.dateTo},
+                pageSize=${filter.pageSize}'
     )">
     </div>
 

--- a/src/main/resources/templates/events/table.html
+++ b/src/main/resources/templates/events/table.html
@@ -44,19 +44,10 @@
     Для редактирования события кликните по ее номеру, для удаления - на крестик.
 </p>
 
-<form action="#" th:action="@{/events/search}" th:object="${filter}" method="post">
-    <div>
-        <label>
-            Счет
-            <select th:field="*{portfolio}">
-                <option th:value="NULL" th:selected/>
-                <option th:each="portfolio : ${portfolios}" th:text="${portfolio}" th:value="${portfolio}"/>
-            </select>
-        </label>
-        <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"/>
-        <div th:replace="fragments/search :: page-size ('*{pageSize}')"/>
-    </div>
-    <input type="submit" value="Поиск"/>
+<form action="#" th:action="@{/events/search}" th:object="${filter}" method="post" class="search-filter">
+    <div th:replace="fragments/search :: portfolio (selected='*{portfolio}', portfolios=${portfolios})"></div>
+    <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"></div>
+    <div th:replace="fragments/search :: page-size ('*{pageSize}')"></div>
 </form>
 
 <table>

--- a/src/main/resources/templates/foreign-exchange-rates/table.html
+++ b/src/main/resources/templates/foreign-exchange-rates/table.html
@@ -36,18 +36,12 @@
 
 <form action="#" th:action="@{/foreign-exchange-rates/search}" th:object="${filter}" method="post">
     <div>
-        <label>
-            Валюта
-            <div th:replace="fragments/search :: currency-picker ('*{currency}')"/>
-        </label>
+        <div th:replace="fragments/search :: currency-picker ('*{currency}')"/>
         <label>
             Дата
             <input type="date" th:field="*{date}" pattern="\d{4}-\d{2}-\d{2}" placeholder="2001-01-31"/>
         </label>
-        <label>
-            Размер страницы
-            <div th:replace="fragments/search :: page-size ('*{pageSize}')"/>
-        </label>
+        <div th:replace="fragments/search :: page-size ('*{pageSize}')"/>
     </div>
     <input type="submit" value="Поиск"/>
 </form>
@@ -77,9 +71,9 @@
 
 <div th:insert="fragments/navigation :: navigation-bar (
         endpoint='foreign-exchange-rates',
-        params='currency=__${filter.currency}__,
-                date=__${filter.date}__,
-                pageSize=__${filter.pageSize}__'
+        params='currency=${filter.currency},
+                date=${filter.date},
+                pageSize=${filter.pageSize}'
     )">
 </div>
 </body>

--- a/src/main/resources/templates/foreign-exchange-rates/table.html
+++ b/src/main/resources/templates/foreign-exchange-rates/table.html
@@ -34,16 +34,10 @@
     Для редактирования курса кликните по его дате, для удаления - на крестик.
 </p>
 
-<form action="#" th:action="@{/foreign-exchange-rates/search}" th:object="${filter}" method="post">
-    <div>
-        <div th:replace="fragments/search :: currency-picker ('*{currency}')"/>
-        <label>
-            Дата
-            <input type="date" th:field="*{date}" pattern="\d{4}-\d{2}-\d{2}" placeholder="2001-01-31"/>
-        </label>
-        <div th:replace="fragments/search :: page-size ('*{pageSize}')"/>
-    </div>
-    <input type="submit" value="Поиск"/>
+<form action="#" th:action="@{/foreign-exchange-rates/search}" th:object="${filter}" method="post" class="search-filter">
+    <div th:replace="fragments/search :: currency-picker ('*{currency}')"></div>
+    <div th:replace="fragments/search :: date ('*{date}')"></div>
+    <div th:replace="fragments/search :: page-size ('*{pageSize}')"></div>
 </form>
 
 <table>
@@ -64,7 +58,8 @@
             class="value"/>
         <td th:text="${rate.quoteCurrency}"/>
         <td class="table-row-control">
-            <a th:href="@{/foreign-exchange-rates/delete(date=${rate.date}, baseCurrency=${rate.baseCurrency}, quoteCurrency=${rate.quoteCurrency})}" title="Удалить">&#x274c;</a>
+            <a th:href="@{/foreign-exchange-rates/delete(date=${rate.date}, baseCurrency=${rate.baseCurrency}, quoteCurrency=${rate.quoteCurrency})}"
+               title="Удалить">&#x274c;</a>
         </td>
     </tr>
 </table>

--- a/src/main/resources/templates/fragments/navigation.html
+++ b/src/main/resources/templates/fragments/navigation.html
@@ -22,25 +22,30 @@
 
 <nav aria-label="Page navigation" th:fragment="navigation-bar(endpoint, params)">
 
-    <ul th:if="${page.total > 1}" class="page-bar">
-        <li class="page-item" th:classappend="${page.previous == null ? 'page-disabled' : ''}">
-            <span th:with="link=@{/__${endpoint}__(__${params}__, page=__${page.previous}__)}">
-                <a class="page-link" th:href="${link}" tabindex="-1" title="Назад">&#129136;</a>
-            </span>
+    <ul th:if="${page.total > 1}" th:with="startPage=${T(java.lang.Math).max(0, page.current - 5)}" class="page-bar">
+        <li th:classappend="${page.isFirst ? 'page-disabled' : ''}">
+            <a class="page-link" th:href="@{/__${endpoint}__(__${params}__, page=__${page.previous}__)}" title="Назад">&#8592;</a>
         </li>
 
-        <th:block th:each="item : ${#numbers.sequence(0, 10, 1)}">
-            <li th:if="${item < page.total}" th:classappend="${item == page.current ? 'page-active' : ''}">
-                <span th:with="link=@{/__${endpoint}__(__${params}__, page=__${item}__)}">
-                    <a class="page-item" th:href="${link}" th:text="${item} + 1"></a>
-                </span>
+        <li th:if="${page.current > 5}">
+            <a th:href="@{/__${endpoint}__(__${params}__, page=0)}">1</a>
+            <span>..</span>
+        </li>
+
+        <th:block th:each="item : ${#numbers.sequence(startPage, T(java.lang.Math).min(startPage + 10, page.total - 1))}">
+            <li th:classappend="${item == page.current ? 'page-active' : ''}">
+                <a th:href="@{/__${endpoint}__(__${params}__, page=__${item}__)}" th:text="${item} + 1"/>
             </li>
         </th:block>
 
-        <li class="page-item" th:classappend="${page.next == null ? 'page-disabled' : ''}">
-            <span th:with="link=@{/__${endpoint}__(__${params}__, page=__${page.next}__)}">
-                <a class="page-link" th:href="${link}" title="Вперед">&#129138;</a>
-            </span>
+        <li th:if="${page.current < page.total - 6}" th:with="lastPage=${page.total} - 1">
+            <span>..</span>
+            <a th:href="@{/__${endpoint}__(__${params}__, page=__${lastPage}__)}" th:text="${page.total}"
+               title="Последняя"/>
+        </li>
+
+        <li class="page-item" th:classappend="${page.isLast ? 'page-disabled' : ''}">
+            <a class="page-link" th:href="@{/__${endpoint}__(__${params}__, page=__${page.next}__)}" title="Вперед">&#8594;</a>
         </li>
     </ul>
 </nav>

--- a/src/main/resources/templates/fragments/search.html
+++ b/src/main/resources/templates/fragments/search.html
@@ -20,32 +20,37 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="ru">
 <body>
 
-<div th:fragment="date-range(from, to)">
-    <div style="display: flex">
+<label th:fragment="date-range(from, to)">
+    Дата
+    <span style="display: flex">
         <input type="date" th:field="__${from}__" pattern="\d{4}-\d{2}-\d{2}" placeholder="2001-01-31"/>
-        <input type="date" th:field="__${to}__" pattern="\d{4}-\d{2}-\d{2}" placeholder="2001-01-31"/>
-    </div>
-</div>
+        <input type="date" th:field="__${to}__" pattern="\d{4}-\d{2}-\d{2}" placeholder="2100-12-31"/>
+    </span>
+</label>
 
-<div th:fragment="page-size(var)">
-    <select th:field="__${var}__" required>
+<label th:fragment="page-size(size)">
+    Размер страницы
+    <select th:field="__${size}__" required>
         <option th:value="10" th:text="10"></option>
         <option th:value="20" th:text="20"></option>
         <option th:value="30" th:text="30"></option>
         <option th:value="50" th:text="50"></option>
+        <option th:value="100" th:text="100"></option>
+        <option th:value="1000" th:text="1000"></option>
     </select>
-</div>
+</label>
 
-<div th:fragment="currency-picker(var)">
-    <select th:field="__${var}__">
-        <option th:value="NULL" th:selected></option>
-        <option th:value="RUB" th:text="RUB"></option>
-        <option th:value="USD" th:text="USD"></option>
-        <option th:value="EUR" th:text="EUR"></option>
-        <option th:value="GBP" th:text="GBP"></option>
-        <option th:value="CHF" th:text="CHF"></option>
-    </select>
-</div>
+<label th:fragment="currency-picker(currency)">
+    Валюта
+    <input type="text" th:field="__${currency}__" list="currencies"/>
+    <datalist id="currencies">
+        <option>RUB</option>
+        <option>USD</option>
+        <option>EUR</option>
+        <option>GBP</option>
+        <option>CHF</option>
+    </datalist>
+</label>
 
 </body>
 </html>

--- a/src/main/resources/templates/fragments/search.html
+++ b/src/main/resources/templates/fragments/search.html
@@ -20,29 +20,49 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="ru">
 <body>
 
+<label th:fragment="portfolio(selected, portfolios)">
+    Счет
+    <select th:field="__${selected}__" onchange="this.form.submit()">
+        <option th:value="NULL" th:text="NULL" th:selected onchange="this.form.submit()"/>
+        <option th:each="portfolio : ${portfolios}" th:value="${portfolio}" th:text="${portfolio}" onchange="this.form.submit()"/>
+    </select>
+</label>
+
+<label th:fragment="security(security)">
+    Инструмент
+    <input type="text" th:field="__${security}__" placeholder="Название / Тикер / ISIN" onchange="this.form.submit()"/>
+</label>
+
+<label th:fragment="date(date)">
+    <label>
+        Дата
+        <input type="date" th:field="__${date}__" pattern="\d{4}-\d{2}-\d{2}" placeholder="2022-01-01" onchange="this.form.submit()"/>
+    </label>
+</label>
+
 <label th:fragment="date-range(from, to)">
     Дата
     <span style="display: flex">
-        <input type="date" th:field="__${from}__" pattern="\d{4}-\d{2}-\d{2}" placeholder="2001-01-31"/>
-        <input type="date" th:field="__${to}__" pattern="\d{4}-\d{2}-\d{2}" placeholder="2100-12-31"/>
+        <input type="date" th:field="__${from}__" pattern="\d{4}-\d{2}-\d{2}" placeholder="2001-01-31" onchange="this.form.submit()"/>
+        <input type="date" th:field="__${to}__" pattern="\d{4}-\d{2}-\d{2}" placeholder="2100-12-31" onchange="this.form.submit()"/>
     </span>
 </label>
 
 <label th:fragment="page-size(size)">
-    Размер страницы
-    <select th:field="__${size}__" required>
+    Количество
+    <select th:field="__${size}__" onchange="this.form.submit()" class="page-size" required>
         <option th:value="10" th:text="10"></option>
         <option th:value="20" th:text="20"></option>
         <option th:value="30" th:text="30"></option>
         <option th:value="50" th:text="50"></option>
         <option th:value="100" th:text="100"></option>
-        <option th:value="1000" th:text="1000"></option>
+        <option th:value="1000000000" th:text="Все"></option>
     </select>
 </label>
 
 <label th:fragment="currency-picker(currency)">
     Валюта
-    <input type="text" th:field="__${currency}__" list="currencies"/>
+    <input class="currency" type="text" th:field="__${currency}__" list="currencies" onchange="this.form.submit()"/>
     <datalist id="currencies">
         <option>RUB</option>
         <option>USD</option>

--- a/src/main/resources/templates/security-deposit/table.html
+++ b/src/main/resources/templates/security-deposit/table.html
@@ -53,10 +53,7 @@
             Инструмент
             <input type="text" th:field="*{security}" placeholder="Название / Тикер / ISIN"/>
         </label>
-        <label>
-            Дата
-            <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"/>
-        </label>
+        <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"/>
     </div>
     <input type="submit" value="Поиск"/>
 </form>
@@ -92,11 +89,11 @@
 
 <div th:insert="fragments/navigation :: navigation-bar (
     endpoint='security-deposit',
-    params='portfolio=__${filter.portfolio}__,
-            dateFrom=__${filter.dateFrom}__,
-            dateTo=__${filter.dateTo}__,
-            security=__${filter.security}__,
-            pageSize=__${filter.pageSize}__'
+    params='portfolio=${filter.portfolio},
+            dateFrom=${filter.dateFrom},
+            dateTo=${filter.dateTo},
+            security=${filter.security},
+            pageSize=${filter.pageSize}'
 )">
 </div>
 

--- a/src/main/resources/templates/security-deposit/table.html
+++ b/src/main/resources/templates/security-deposit/table.html
@@ -40,22 +40,10 @@
     Для редактирования сделки кликните по ее номеру, для удаления - на крестик.
 </p>
 
-<form action="#" th:action="@{/security-deposit/search}" th:object="${filter}" method="post">
-    <div>
-        <label>
-            Счет
-            <select th:field="*{portfolio}">
-                <option th:value="NULL" th:selected/>
-                <option th:each="portfolio : ${portfolios}" th:text="${portfolio}" th:value="${portfolio}"/>
-            </select>
-        </label>
-        <label>
-            Инструмент
-            <input type="text" th:field="*{security}" placeholder="Название / Тикер / ISIN"/>
-        </label>
-        <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"/>
-    </div>
-    <input type="submit" value="Поиск"/>
+<form action="#" th:action="@{/security-deposit/search}" th:object="${filter}" method="post" class="search-filter">
+    <div th:replace="fragments/search :: portfolio (selected='*{portfolio}', portfolios=${portfolios})"></div>
+    <div th:replace="fragments/search :: security ('*{security}')"></div>
+    <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"></div>
 </form>
 
 <table>

--- a/src/main/resources/templates/security-events/table.html
+++ b/src/main/resources/templates/security-events/table.html
@@ -44,23 +44,11 @@
     Для редактирования события кликните по ее номеру, для удаления - на крестик.
 </p>
 
-<form action="#" th:action="@{/security-events/search}" th:object="${filter}" method="post">
-    <div>
-        <label>
-            Счет
-            <select th:field="*{portfolio}">
-                <option th:value="NULL" th:selected/>
-                <option th:each="portfolio : ${portfolios}" th:text="${portfolio}" th:value="${portfolio}"/>
-            </select>
-        </label>
-        <label>
-            Инструмент
-            <input type="text" th:field="*{security}" placeholder="Название / Тикер / ISIN"/>
-        </label>
-        <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"/>
-        <div th:replace="fragments/search :: page-size ('*{pageSize}')"/>
-    </div>
-    <input type="submit" value="Поиск"/>
+<form action="#" th:action="@{/security-events/search}" th:object="${filter}" method="post" class="search-filter">
+    <div th:replace="fragments/search :: portfolio (selected='*{portfolio}', portfolios=${portfolios})"></div>
+    <div th:replace="fragments/search :: security ('*{security}')"></div>
+    <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"></div>
+    <div th:replace="fragments/search :: page-size ('*{pageSize}')"></div>
 </form>
 
 <table>

--- a/src/main/resources/templates/security-events/table.html
+++ b/src/main/resources/templates/security-events/table.html
@@ -57,14 +57,8 @@
             Инструмент
             <input type="text" th:field="*{security}" placeholder="Название / Тикер / ISIN"/>
         </label>
-        <label>
-            Дата
-            <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"/>
-        </label>
-        <label>
-            Размер страницы
-            <div th:replace="fragments/search :: page-size ('*{pageSize}')"/>
-        </label>
+        <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"/>
+        <div th:replace="fragments/search :: page-size ('*{pageSize}')"/>
     </div>
     <input type="submit" value="Поиск"/>
 </form>
@@ -111,11 +105,11 @@
 
 <div th:insert="fragments/navigation :: navigation-bar (
         endpoint='security-events',
-        params='portfolio=__${filter.portfolio}__,
-                dateFrom=__${filter.dateFrom}__,
-                dateTo=__${filter.dateTo}__,
-                security=__${filter.security}__,
-                pageSize=__${filter.pageSize}__'
+        params='portfolio=${filter.portfolio},
+                dateFrom=${filter.dateFrom},
+                dateTo=${filter.dateTo},
+                security=${filter.security},
+                pageSize=${filter.pageSize}'
 )">
 
 </div>

--- a/src/main/resources/templates/security-quotes/table.html
+++ b/src/main/resources/templates/security-quotes/table.html
@@ -42,20 +42,10 @@
     Для редактирования котировки кликните по ее номеру, для удаления - на крестик.
 </p>
 
-<form action="#" th:action="@{/security-quotes/search}" th:object="${filter}" method="post">
-    <div>
-        <label>
-            Инструмент
-            <input type="text" th:field="*{security}" placeholder="Название / Тикер / ISIN"/>
-        </label>
-        <div th:replace="fragments/search :: currency-picker ('*{currency}')"/>
-        <label>
-            Дата
-            <input type="date" th:field="*{date}" pattern="\d{4}-\d{2}-\d{2}" placeholder="2001-01-31"/>
-        </label>
-        <div th:replace="fragments/search :: page-size ('*{pageSize}')"/>
-    </div>
-    <input type="submit" value="Поиск"/>
+<form action="#" th:action="@{/security-quotes/search}" th:object="${filter}" method="post" class="search-filter">
+    <div th:replace="fragments/search :: security ('*{security}')"></div>
+    <div th:replace="fragments/search :: date ('*{date}')"></div>
+    <div th:replace="fragments/search :: page-size ('*{pageSize}')"></div>
 </form>
 
 <table>

--- a/src/main/resources/templates/security-quotes/table.html
+++ b/src/main/resources/templates/security-quotes/table.html
@@ -48,18 +48,12 @@
             Инструмент
             <input type="text" th:field="*{security}" placeholder="Название / Тикер / ISIN"/>
         </label>
-        <label>
-            Валюта
-            <div th:replace="fragments/search :: currency-picker ('*{currency}')"/>
-        </label>
+        <div th:replace="fragments/search :: currency-picker ('*{currency}')"/>
         <label>
             Дата
             <input type="date" th:field="*{date}" pattern="\d{4}-\d{2}-\d{2}" placeholder="2001-01-31"/>
         </label>
-        <label>
-            Размер страницы
-            <div th:replace="fragments/search :: page-size ('*{pageSize}')"/>
-        </label>
+        <div th:replace="fragments/search :: page-size ('*{pageSize}')"/>
     </div>
     <input type="submit" value="Поиск"/>
 </form>
@@ -94,10 +88,10 @@
 
 <div th:insert="fragments/navigation :: navigation-bar (
         endpoint='security-quotes',
-        params='security=__${filter.security}__,
-                date=__${filter.date}__,
-                currency=__${filter.currency}__,
-                pageSize=__${filter.pageSize}__'
+        params='security=${filter.security},
+                date=${filter.date},
+                currency=${filter.currency},
+                pageSize=${filter.pageSize}'
     )">
 </div>
 

--- a/src/main/resources/templates/transactions/table.html
+++ b/src/main/resources/templates/transactions/table.html
@@ -39,23 +39,11 @@
     Для редактирования сделки кликните по ее номеру, для удаления - на крестик.
 </p>
 
-<form action="#" th:action="@{/transactions/search}" th:object="${filter}" method="post">
-    <div>
-        <label>
-            Счет
-            <select th:field="*{portfolio}">
-                <option th:value="NULL" th:selected/>
-                <option th:each="portfolio : ${portfolios}" th:text="${portfolio}" th:value="${portfolio}"/>
-            </select>
-        </label>
-        <label>
-            Инструмент
-            <input type="text" th:field="*{security}" placeholder="Название / Тикер / ISIN"/>
-        </label>
-        <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"/>
-        <div th:replace="fragments/search :: page-size ('*{pageSize}')"/>
-    </div>
-    <input type="submit" value="Поиск"/>
+<form action="#" th:action="@{/transactions/search}" th:object="${filter}" method="post" class="search-filter">
+    <div th:replace="fragments/search :: portfolio (selected='*{portfolio}', portfolios=${portfolios})"></div>
+    <div th:replace="fragments/search :: security ('*{security}')"></div>
+    <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"></div>
+    <div th:replace="fragments/search :: page-size ('*{pageSize}')"></div>
 </form>
 
 <table>

--- a/src/main/resources/templates/transactions/table.html
+++ b/src/main/resources/templates/transactions/table.html
@@ -52,14 +52,8 @@
             Инструмент
             <input type="text" th:field="*{security}" placeholder="Название / Тикер / ISIN"/>
         </label>
-        <label>
-            Дата
-            <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"/>
-        </label>
-        <label>
-            Размер страницы
-            <div th:replace="fragments/search :: page-size ('*{pageSize}')"/>
-        </label>
+        <div th:replace="fragments/search :: date-range (from='*{dateFrom}', to='*{dateTo}')"/>
+        <div th:replace="fragments/search :: page-size ('*{pageSize}')"/>
     </div>
     <input type="submit" value="Поиск"/>
 </form>
@@ -108,11 +102,11 @@
 
 <div th:insert="fragments/navigation :: navigation-bar (
     endpoint='transactions',
-    params='portfolio=__${filter.portfolio}__,
-            dateFrom=__${filter.dateFrom}__,
-            dateTo=__${filter.dateTo}__,
-            security=__${filter.security}__,
-            pageSize=__${filter.pageSize}__'
+    params='portfolio=${filter.portfolio},
+            dateFrom=${filter.dateFrom},
+            dateTo=${filter.dateTo},
+            security=${filter.security},
+            pageSize=${filter.pageSize}'
 )">
 </div>
 


### PR DESCRIPTION
Реквест вносит изменения по замечаниям из gh-495

Relates gh-430

- Убрана кнопка "Поиск", при изменении любого поля, таблица фильтруется автоматически.
- В навигации под таблицей Первая и Последняя страницы отображаются всегда.
- Можно отображать от 10 до всех элементов. Последний случай удобно, если нужно распечатать или выполнить поиск средствами браузера. 
- По умолчанию задано 10 строк в таблице, чтобы ссылки навигации были всегда на экране для экранов от 23'.
- Поля фильтров отцентрованы.

![изображение](https://user-images.githubusercontent.com/11336712/188021164-89ac23e4-6887-4922-b144-77fb18b37315.png)
