### PR TITLE
Исправление сборки docker образа для Docker Hub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -429,7 +429,7 @@
                                 </tags>
                                 <publish>true</publish>
                                 <env>
-                                    <BP_JVM_VERSION>${java.version}</BP_JVM_VERSION>
+                                    <BP_JVM_VERSION>19</BP_JVM_VERSION> <!-- version >= ${java.version} -->
                                     <BPE_LANG>C.UTF-8</BPE_LANG>
                                 </env>
                             </image>


### PR DESCRIPTION
Текущая версия paketo-buildpacks/bellsoft-liberica 9.10.0 перестала подддерживать java 18. Переключился на java 19 внутри докер образа.

https://github.com/paketo-buildpacks/bellsoft-liberica/releases/tag/v9.10.0