### PR TITLE
Изменить котировку по умолчанию для инструмента GLDRUB_TOM

### DIFF
--- a/src/main/java/ru/investbook/report/ForeignExchangeRateService.java
+++ b/src/main/java/ru/investbook/report/ForeignExchangeRateService.java
@@ -46,10 +46,10 @@ public class ForeignExchangeRateService {
     public static final String RUB = "RUB";
     private static final BigDecimal _13 = BigDecimal.valueOf(13);
     private static final BigDecimal _15 = BigDecimal.valueOf(15);
-    private static final BigDecimal _80 = BigDecimal.valueOf(80);
     private static final BigDecimal _100 = BigDecimal.valueOf(100);
     private static final BigDecimal _110 = BigDecimal.valueOf(110);
     private static final BigDecimal _120 = BigDecimal.valueOf(120);
+    private static final BigDecimal _6000 = BigDecimal.valueOf(6000);
     private final ForeignExchangeRateRepository foreignExchangeRateRepository;
     // base-currency -> quote-currency -> exchange-rate
     private final Map<String, Map<String, BigDecimal>> cache = new ConcurrentHashMap<>();
@@ -237,7 +237,8 @@ public class ForeignExchangeRateService {
             case "GBP" -> _120;
             case "CNY" -> _15;
             case "HKD" -> _13;
-            default -> _80;
+            case "GLD" -> _6000;
+            default -> _100;
         };
         log.debug("Не могу в БД найти курс валюты {}, использую значение по умолчанию = {}",
                 currency, exchangeRate);

--- a/src/main/resources/db/migration/h2/V2023_4_0_0.sql
+++ b/src/main/resources/db/migration/h2/V2023_4_0_0.sql
@@ -1,0 +1,20 @@
+/*
+ * InvestBook
+ * Copyright (C) 2023  Spacious Team <spacious-team@ya.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+ALTER TABLE `foreign_exchange_rate`
+    ALTER COLUMN `rate` DECIMAL(15,6) NOT NULL COMMENT 'Официальный обменный курс ЦБ';

--- a/src/main/resources/db/migration/mariadb/V2023_4_0_0.sql
+++ b/src/main/resources/db/migration/mariadb/V2023_4_0_0.sql
@@ -1,0 +1,20 @@
+/*
+ * InvestBook
+ * Copyright (C) 2023  Spacious Team <spacious-team@ya.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+ALTER TABLE `foreign_exchange_rate` CHANGE COLUMN `rate`
+    `rate` DECIMAL(15,6) NOT NULL COMMENT 'Официальный обменный курс ЦБ' AFTER `currency_pair`;


### PR DESCRIPTION
1. Котировка по умолчанию для всех инструментов `*_TOM` валютной секции МосБиржи (отличных от USD, EUR, GBP, CHF, CNY, HKD) составляет 100 руб за единицу. Для инструмента GLDRUB_TOM задан дефолт 6000 руб за контракт. 

Текущая котировка  GLDRUB_TOM из отчетов брокера не парсится, но может быть задана в ручную для оценки бумажной прибыли. Для этого нужно перейти по ссылкам с главной страницы `Формы -> Обменные курсы -> Добавить`.
![изображение](https://github.com/spacious-team/investbook/assets/11336712/ce77140e-f537-4403-97e6-1bb522d4e087)

2.  В рамках этого PR расширена поддержка котировок с 3 цифр до запятой и 4 цифр после запятой до 9 цифр до запятой и 6 цифр после.
