### PR TITLE
Обновить Spring Boot до 3.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.7</version> <!-- Обновлять с учетом https://github.com/spacious-team/investbook/issues/545 -->
+        <version>3.2.5</version> <!-- Обновлять с учетом https://github.com/spacious-team/investbook/issues/545 -->
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>ru.investbook</groupId>
@@ -64,7 +64,6 @@
         <!-- Valid version is (0-255).(0-255).(0-65535) -->
         <win.msi.version>24.2</win.msi.version>
         <java.version>21</java.version>
-        <hibernate.version>6.4.4.Final</hibernate.version>  <!-- remove if Spring Boot updated to >= 3.2.4 -->
     </properties>
 
     <repositories>

--- a/src/main/java/ru/investbook/entity/AssignedOrIdentityGenerator.java
+++ b/src/main/java/ru/investbook/entity/AssignedOrIdentityGenerator.java
@@ -31,7 +31,7 @@ import org.hibernate.id.IdentityGenerator;
  * <p>
  * Applicable only for INSERT operations.
  */
-class AssignedOrIdentityGenerator extends BeforeOrOnExecutionGenerator {
+public class AssignedOrIdentityGenerator extends BeforeOrOnExecutionGenerator {
 
     @SuppressWarnings("unused")
     public AssignedOrIdentityGenerator() {


### PR DESCRIPTION
Обновление Spring Boot потребует миграции БД.
В коде оставлен TODO. Миграцию выполнить отдельным PR.

Relates #545