### PR TITLE
Исправлена сборка docker образа

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -410,6 +410,11 @@
                     <plugin>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
+                        <!--
+                            Remove after spring-boot-starter-parent upgrade
+                            https://github.com/spring-projects/spring-boot/issues/39323
+                        -->
+                        <version>3.1.9</version>
                         <configuration>
                             <layers>
                                 <enabled>true</enabled>
@@ -427,7 +432,7 @@
                                     <!-- Defines available bellsoft-liberica java versions from
                                     https://github.com/paketo-buildpacks/java/releases
                                     JRE with ${java.version} will be selected automatically when available -->
-                                    <buildpack>gcr.io/paketo-buildpacks/java:10.2.1</buildpack>
+                                    <buildpack>gcr.io/paketo-buildpacks/java:15.2.0</buildpack>
                                 </buildpacks>
                             </image>
                             <docker>


### PR DESCRIPTION
Ошибка связана с переходом GitHub Actions на Docker 25+ и старой версией плагина spring-boot-maven-plugin.
Пришлось обновить также paketo-buildpacks/java, без этого сборка зависала.

https://github.com/spring-projects/spring-boot/issues/39323