### PR TITLE
Рефакторинг кода обращения к БД

### DIFF
--- a/src/main/java/ru/investbook/api/AbstractEntityRepositoryService.java
+++ b/src/main/java/ru/investbook/api/AbstractEntityRepositoryService.java
@@ -1,0 +1,151 @@
+/*
+ * InvestBook
+ * Copyright (C) 2024  Spacious Team <spacious-team@ya.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ru.investbook.api;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Session;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import ru.investbook.converter.EntityConverter;
+
+import java.util.Optional;
+
+import static org.springframework.transaction.TransactionDefinition.PROPAGATION_REQUIRES_NEW;
+import static ru.investbook.repository.RepositoryHelper.isUniqIndexViolationException;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class AbstractEntityRepositoryService<ID, Pojo, Entity> implements EntityRepositoryService<ID, Pojo> {
+    private final JpaRepository<Entity, ID> repository;
+    private final EntityConverter<Entity, Pojo> converter;
+    @Autowired
+    private EntityManager entityManager;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+    private TransactionTemplate transactionTemplateRequired;
+    private TransactionTemplate transactionTemplateRequiresNew;
+
+    @PostConstruct
+    void init() {
+        transactionTemplateRequired = new TransactionTemplate(transactionManager);
+        transactionTemplateRequiresNew = new TransactionTemplate(transactionManager);
+        transactionTemplateRequiresNew.setPropagationBehavior(PROPAGATION_REQUIRES_NEW);
+    }
+
+    @Override
+    public boolean existsById(ID id) {
+        return repository.existsById(id);
+    }
+
+    @Override
+    public Optional<Pojo> getById(ID id) {
+        return repository.findById(id)
+                .map(converter::fromEntity);
+    }
+
+    @Override
+    public Page<Pojo> get(Pageable pageable) {
+        return repository.findAll(pageable)
+                .map(converter::fromEntity);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean insert(Pojo object) {
+        if (entityManager instanceof Session hibernateSpecificSession) {
+            try {
+                Entity entity = converter.toEntity(object);
+                transactionTemplateRequiresNew.executeWithoutResult(_ -> hibernateSpecificSession.save(entity));
+                return true;
+            } catch (Exception e) {
+                if (isUniqIndexViolationException(e)) {
+                    return false; // can't insert, object with same ID already exists in DB or unique key constraint violation
+                }
+                log.error("Can't INSERT by optimized deprecated Hibernate method save(): {}", object, e);
+            }
+        }
+        Boolean result = transactionTemplateRequired.execute(_ -> create(object));
+        return Boolean.TRUE.equals(result);
+    }
+
+    @Override
+    @Transactional
+    public boolean create(Pojo object) {
+        return createInternal(object)
+                .isPresent();
+    }
+
+    @Override
+    @Transactional
+    public Optional<Pojo> createAndGet(Pojo object) {
+        return createInternal(object)
+                .map(converter::fromEntity);
+    }
+
+    /**
+     * Creates a new object (with SELECT check)
+     *
+     * @return created entity if object is created or empty Optional otherwise
+     * @implSpec Should be called in transaction
+     */
+    private Optional<Entity> createInternal(Pojo object) {
+        ID id = getId(object);
+        if (id != null && existsById(id)) {
+            return Optional.empty();
+        }
+        // Если работать не в транзакции, то следующая строка может повторно создать объект.
+        // Это возможно, если объект был создан другим потоком после проверки существования строки по ID.
+        // Метод должен работать в транзакции.
+        Entity savedEntity = createOrUpdateInternal(object);
+        return Optional.of(savedEntity);
+    }
+
+    @Override
+    @Transactional
+    public void createOrUpdate(Pojo object) {
+        createOrUpdateInternal(object);
+    }
+
+    @Override
+    @Transactional
+    public Pojo createOrUpdateAndGet(Pojo object) {
+        Entity savedEntity = createOrUpdateInternal(object);
+        return converter.fromEntity(savedEntity);
+    }
+
+    private Entity createOrUpdateInternal(Pojo object) {
+        Entity entity = converter.toEntity(object);
+        return repository.save(entity);
+    }
+
+    @Override
+    public void deleteById(ID id) {
+        repository.deleteById(id);
+    }
+
+    protected abstract ID getId(Pojo object);
+}

--- a/src/main/java/ru/investbook/api/AbstractEntityRepositoryService.java
+++ b/src/main/java/ru/investbook/api/AbstractEntityRepositoryService.java
@@ -68,7 +68,7 @@ public abstract class AbstractEntityRepositoryService<ID, Pojo, Entity> implemen
     }
 
     @Override
-    public Page<Pojo> get(Pageable pageable) {
+    public Page<Pojo> getPage(Pageable pageable) {
         return repository.findAll(pageable)
                 .map(converter::fromEntity);
     }
@@ -146,6 +146,4 @@ public abstract class AbstractEntityRepositoryService<ID, Pojo, Entity> implemen
     public void deleteById(ID id) {
         repository.deleteById(id);
     }
-
-    protected abstract ID getId(Pojo object);
 }

--- a/src/main/java/ru/investbook/api/AbstractRestController.java
+++ b/src/main/java/ru/investbook/api/AbstractRestController.java
@@ -69,7 +69,7 @@ public abstract class AbstractRestController<ID, Pojo, Entity> extends AbstractE
     @Transactional
     protected ResponseEntity<Void> post(Pojo object) {
         try {
-            return createAndGet(object)
+            return createAndGetIfAbsent(object)
                     .map(this::createResponseWithLocationHeader)
                     .orElseGet(() -> ResponseEntity
                             .status(HttpStatus.CONFLICT)
@@ -100,7 +100,7 @@ public abstract class AbstractRestController<ID, Pojo, Entity> extends AbstractE
                         "запроса [" + objectId + "] не совпадают");
             }
             Pojo objectWithId = nonNull(objectId) ? object : updateId(id, object);
-            return createAndGet(objectWithId)
+            return createAndGetIfAbsent(objectWithId)
                     .map(this::createResponseWithLocationHeader)
                     .orElseGet(() -> {
                         createOrUpdate(objectWithId);

--- a/src/main/java/ru/investbook/api/AbstractRestController.java
+++ b/src/main/java/ru/investbook/api/AbstractRestController.java
@@ -20,6 +20,8 @@ package ru.investbook.api;
 
 import jakarta.persistence.GeneratedValue;
 import lombok.SneakyThrows;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -37,6 +39,10 @@ public abstract class AbstractRestController<ID, Pojo, Entity> extends AbstractE
 
     protected AbstractRestController(JpaRepository<Entity, ID> repository, EntityConverter<Entity, Pojo> converter) {
         super(repository, converter);
+    }
+
+    public Page<Pojo> get(Pageable pageable) {
+        return getPage(pageable);
     }
 
     /**

--- a/src/main/java/ru/investbook/api/AbstractRestController.java
+++ b/src/main/java/ru/investbook/api/AbstractRestController.java
@@ -106,11 +106,11 @@ public abstract class AbstractRestController<ID, Pojo, Entity> extends AbstractE
     }
 
     /**
-     * Deletes object from storage. Always return OK http status with empty body.
+     * Deletes object from storage. Always return "204 No Content" http status with empty body.
      */
-    // TODO should impl 404 status? https://stackoverflow.com/questions/4088350/is-rest-delete-really-idempotent
-    public void delete(ID id) {
+    public ResponseEntity<Void> delete(ID id) {
         deleteById(id);
+        return ResponseEntity.noContent().build();
     }
 
     /**

--- a/src/main/java/ru/investbook/api/AbstractRestController.java
+++ b/src/main/java/ru/investbook/api/AbstractRestController.java
@@ -69,12 +69,16 @@ public abstract class AbstractRestController<ID, Pojo, Entity> extends AbstractE
     @Transactional
     protected ResponseEntity<Void> post(Pojo object) {
         try {
-            return createAndGetIfAbsent(object)
-                    .map(this::createResponseWithLocationHeader)
-                    .orElseGet(() -> ResponseEntity
-                            .status(HttpStatus.CONFLICT)
-                            .location(getLocationURI(object))
-                            .build());
+            CreateResult<Pojo> result = createIfAbsentAndGet(object);
+            Pojo savedObject = result.object();
+            if (result.created()) {
+                return createResponseWithLocationHeader(savedObject);
+            } else {
+                return ResponseEntity
+                        .status(HttpStatus.CONFLICT)
+                        .location(getLocationURI(savedObject))
+                        .build();
+            }
         } catch (Exception e) {
             throw new InternalServerErrorException("Не могу создать объект", e);
         }

--- a/src/main/java/ru/investbook/api/CreateResult.java
+++ b/src/main/java/ru/investbook/api/CreateResult.java
@@ -1,0 +1,33 @@
+/*
+ * InvestBook
+ * Copyright (C) 2024  Spacious Team <spacious-team@ya.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ru.investbook.api;
+
+/**
+ * @param created true is new object was created, false if existing object is returned
+ */
+public record CreateResult<T>(T object, boolean created) {
+
+    public static <T> CreateResult<T> created(T object) {
+        return new CreateResult<>(object, true);
+    }
+
+    public static <T> CreateResult<T> selected(T object) {
+        return new CreateResult<>(object, false);
+    }
+}

--- a/src/main/java/ru/investbook/api/EntityRepositoryService.java
+++ b/src/main/java/ru/investbook/api/EntityRepositoryService.java
@@ -25,17 +25,20 @@ import java.util.Optional;
 
 public interface EntityRepositoryService<ID, Pojo> {
 
+    ID getId(Pojo object);
+
     boolean existsById(ID id);
 
     Optional<Pojo> getById(ID id);
 
-    Page<Pojo> get(Pageable pageable);
+    Page<Pojo> getPage(Pageable pageable);
 
     /**
      * Creates a new object with direct INSERT into DB (without prior SELECT call) if possible,
      * calls {@link #create(Object)} otherwise.
      *
-     * @return true if object is created or false otherwise
+     * @return true if object is created, false if object with ID already exists
+     * @throws RuntimeException if an INSERT error occurs
      * @implNote Method performance is the same as {@link #create(Object)} for H2 2.2.224 and MariaDB 11.2
      */
     boolean insert(Pojo object);
@@ -44,7 +47,8 @@ public interface EntityRepositoryService<ID, Pojo> {
      * Creates new object, doesn't update.
      * Calls SELECT to check if object's ID exists in DB.
      *
-     * @return true if object was created, false if object with ID already exists or other INSERT error was occurred
+     * @return true if object was created, false if object with ID already exists
+     * @throws RuntimeException if an INSERT error occurs
      * @see #insert(Object)
      */
     boolean create(Pojo object);
@@ -54,7 +58,8 @@ public interface EntityRepositoryService<ID, Pojo> {
      * Calls SELECT to check if object's ID exists in DB.
      * Use faster {@link #create(Object)} method if saved object is not required
      *
-     * @return saved object or empty Optional if object with ID already exists or other INSERT error was occurred
+     * @return created object or empty Optional if object with ID already exists
+     * @throws RuntimeException if an INSERT error occurs
      * @see #create(Object)
      */
     Optional<Pojo> createAndGet(Pojo object);
@@ -63,6 +68,8 @@ public interface EntityRepositoryService<ID, Pojo> {
      * Create new or update existing object in DB.
      * Use instead of the slower method {@link #createOrUpdateAndGet(Object)}
      * if saved object is not required
+     *
+     * @throws RuntimeException if underlying DB error occurs
      */
     void createOrUpdate(Pojo object);
 
@@ -70,6 +77,7 @@ public interface EntityRepositoryService<ID, Pojo> {
      * Create new or update existing object in DB.
      *
      * @return the saved object (some fields, such as ID, may be set by the DBMS)
+     * @throws RuntimeException if underlying DB error occurs
      * @see #createOrUpdate(Object)
      */
     Pojo createOrUpdateAndGet(Pojo object);

--- a/src/main/java/ru/investbook/api/EntityRepositoryService.java
+++ b/src/main/java/ru/investbook/api/EntityRepositoryService.java
@@ -1,0 +1,78 @@
+/*
+ * InvestBook
+ * Copyright (C) 2024  Spacious Team <spacious-team@ya.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ru.investbook.api;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface EntityRepositoryService<ID, Pojo> {
+
+    boolean existsById(ID id);
+
+    Optional<Pojo> getById(ID id);
+
+    Page<Pojo> get(Pageable pageable);
+
+    /**
+     * Creates a new object with direct INSERT into DB (without prior SELECT call) if possible,
+     * calls {@link #create(Object)} otherwise.
+     *
+     * @return true if object is created or false otherwise
+     * @implNote Method performance is the same as {@link #create(Object)} for H2 2.2.224 and MariaDB 11.2
+     */
+    boolean insert(Pojo object);
+
+    /**
+     * Creates new object, doesn't update.
+     * Calls SELECT to check if object's ID exists in DB.
+     *
+     * @return true if object was created, false if object with ID already exists or other INSERT error was occurred
+     * @see #insert(Object)
+     */
+    boolean create(Pojo object);
+
+    /**
+     * Creates new object, doesn't update.
+     * Calls SELECT to check if object's ID exists in DB.
+     * Use faster {@link #create(Object)} method if saved object is not required
+     *
+     * @return saved object or empty Optional if object with ID already exists or other INSERT error was occurred
+     * @see #create(Object)
+     */
+    Optional<Pojo> createAndGet(Pojo object);
+
+    /**
+     * Create new or update existing object in DB.
+     * Use instead of the slower method {@link #createOrUpdateAndGet(Object)}
+     * if saved object is not required
+     */
+    void createOrUpdate(Pojo object);
+
+    /**
+     * Create new or update existing object in DB.
+     *
+     * @return the saved object (some fields, such as ID, may be set by the DBMS)
+     * @see #createOrUpdate(Object)
+     */
+    Pojo createOrUpdateAndGet(Pojo object);
+
+    void deleteById(ID id);
+}

--- a/src/main/java/ru/investbook/api/EntityRepositoryService.java
+++ b/src/main/java/ru/investbook/api/EntityRepositoryService.java
@@ -35,11 +35,10 @@ public interface EntityRepositoryService<ID, Pojo> {
 
     /**
      * Creates a new object with direct INSERT into DB (without prior SELECT call) if possible,
-     * calls {@link #create(Object)} otherwise.
+     * calls {@link #createIfAbsent(Object)} otherwise.
      *
      * @return true if object is created, false if object with ID already exists
-     * @throws RuntimeException if an INSERT error occurs
-     * @implNote Method performance is the same as {@link #create(Object)} for H2 2.2.224 and MariaDB 11.2
+     * @throws RuntimeException if object not exists and an INSERT error occurs
      */
     boolean insert(Pojo object);
 
@@ -48,21 +47,21 @@ public interface EntityRepositoryService<ID, Pojo> {
      * Calls SELECT to check if object's ID exists in DB.
      *
      * @return true if object was created, false if object with ID already exists
-     * @throws RuntimeException if an INSERT error occurs
+     * @throws RuntimeException if object not exists and an INSERT error occurs
      * @see #insert(Object)
      */
-    boolean create(Pojo object);
+    boolean createIfAbsent(Pojo object);
 
     /**
      * Creates new object, doesn't update.
      * Calls SELECT to check if object's ID exists in DB.
-     * Use faster {@link #create(Object)} method if saved object is not required
+     * Use faster {@link #createIfAbsent(Object)} method if saved object is not required
      *
      * @return created object or empty Optional if object with ID already exists
-     * @throws RuntimeException if an INSERT error occurs
-     * @see #create(Object)
+     * @throws RuntimeException if object not exists and an INSERT error occurs
+     * @see #createIfAbsent(Object)
      */
-    Optional<Pojo> createAndGet(Pojo object);
+    Optional<Pojo> createAndGetIfAbsent(Pojo object);
 
     /**
      * Create new or update existing object in DB.

--- a/src/main/java/ru/investbook/api/EntityRepositoryService.java
+++ b/src/main/java/ru/investbook/api/EntityRepositoryService.java
@@ -64,6 +64,17 @@ public interface EntityRepositoryService<ID, Pojo> {
     Optional<Pojo> createAndGetIfAbsent(Pojo object);
 
     /**
+     * Creates new object, doesn't update.
+     * Calls SELECT to check if object's ID exists in DB.
+     * Use faster {@link #createIfAbsent(Object)} method if saved object is not required
+     *
+     * @return created object or existing object without update if object with ID already exists
+     * @throws RuntimeException if object not exists and an INSERT error occurs
+     * @see #createIfAbsent(Object)
+     */
+    CreateResult<Pojo> createIfAbsentAndGet(Pojo object);
+
+    /**
      * Create new or update existing object in DB.
      * Use instead of the slower method {@link #createOrUpdateAndGet(Object)}
      * if saved object is not required

--- a/src/main/java/ru/investbook/api/EventCashFlowRestController.java
+++ b/src/main/java/ru/investbook/api/EventCashFlowRestController.java
@@ -39,8 +39,6 @@ import org.springframework.web.bind.annotation.RestController;
 import ru.investbook.converter.EntityConverter;
 import ru.investbook.entity.EventCashFlowEntity;
 
-import java.util.Optional;
-
 @RestController
 @Tag(name = "Движения ДС по счету", description = """
         Ввод, вывод ДС, налоги, комиссии, а также дивиденды, купоны, амортизации по бумагам другого счета
@@ -97,11 +95,6 @@ public class EventCashFlowRestController extends AbstractRestController<Integer,
                        @Parameter(description = "Номер события")
                        Integer id) {
         super.delete(id);
-    }
-
-    @Override
-    protected Optional<EventCashFlowEntity> getById(Integer id) {
-        return repository.findById(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/EventCashFlowRestController.java
+++ b/src/main/java/ru/investbook/api/EventCashFlowRestController.java
@@ -98,7 +98,7 @@ public class EventCashFlowRestController extends AbstractRestController<Integer,
     }
 
     @Override
-    protected Integer getId(EventCashFlow object) {
+    public Integer getId(EventCashFlow object) {
         return object.getId();
     }
 

--- a/src/main/java/ru/investbook/api/EventCashFlowRestController.java
+++ b/src/main/java/ru/investbook/api/EventCashFlowRestController.java
@@ -91,10 +91,10 @@ public class EventCashFlowRestController extends AbstractRestController<Integer,
     @Override
     @DeleteMapping("{id}")
     @Operation(summary = "Удалить", description = "Удалить информацию из БД")
-    public void delete(@PathVariable("id")
+    public ResponseEntity<Void> delete(@PathVariable("id")
                        @Parameter(description = "Номер события")
                        Integer id) {
-        super.delete(id);
+        return super.delete(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/ForeignExchangeRateRestController.java
+++ b/src/main/java/ru/investbook/api/ForeignExchangeRateRestController.java
@@ -133,7 +133,7 @@ public class ForeignExchangeRateRestController extends AbstractRestController<Fo
      */
     @DeleteMapping("/currency-pairs/{currency-pair}/dates/{date}")
     @Operation(summary = "Удалить", description = "Удаляет информацию о курсе из БД")
-    public void delete(@PathVariable("currency-pair")
+    public ResponseEntity<Void> delete(@PathVariable("currency-pair")
                        @Parameter(description = "Валютная пара", example = "USDRUB")
                        String currencyPair,
                        @PathVariable("date")
@@ -141,7 +141,7 @@ public class ForeignExchangeRateRestController extends AbstractRestController<Fo
                        @DateTimeFormat(pattern = "yyyy-MM-dd")
                        LocalDate date) {
         foreignExchangeRateService.invalidateCache();
-        super.delete(getId(currencyPair, date));
+        return super.delete(getId(currencyPair, date));
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/ForeignExchangeRateRestController.java
+++ b/src/main/java/ru/investbook/api/ForeignExchangeRateRestController.java
@@ -145,7 +145,7 @@ public class ForeignExchangeRateRestController extends AbstractRestController<Fo
     }
 
     @Override
-    protected ForeignExchangeRateEntityPk getId(ForeignExchangeRate object) {
+    public ForeignExchangeRateEntityPk getId(ForeignExchangeRate object) {
         return getId(object.getCurrencyPair(), object.getDate());
     }
 

--- a/src/main/java/ru/investbook/api/ForeignExchangeRateRestController.java
+++ b/src/main/java/ru/investbook/api/ForeignExchangeRateRestController.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.SneakyThrows;
 import org.spacious_team.broker.pojo.ForeignExchangeRate;
 import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.data.domain.Page;
@@ -43,10 +44,8 @@ import ru.investbook.report.ForeignExchangeRateService;
 import ru.investbook.repository.ForeignExchangeRateRepository;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RestController
@@ -54,6 +53,7 @@ import java.util.stream.Collectors;
 @RequestMapping("/api/v1/foreign-exchange-rates")
 public class ForeignExchangeRateRestController extends AbstractRestController<ForeignExchangeRateEntityPk, ForeignExchangeRate, ForeignExchangeRateEntity> {
     private final ForeignExchangeRateRepository foreignExchangeRateRepository;
+    private final ForeignExchangeRateConverter foreignExchangeRateConverter;
     private final ForeignExchangeRateService foreignExchangeRateService;
 
     public ForeignExchangeRateRestController(ForeignExchangeRateRepository repository,
@@ -61,6 +61,7 @@ public class ForeignExchangeRateRestController extends AbstractRestController<Fo
                                              ForeignExchangeRateService foreignExchangeRateService) {
         super(repository, converter);
         this.foreignExchangeRateRepository = repository;
+        this.foreignExchangeRateConverter = converter;
         this.foreignExchangeRateService = foreignExchangeRateService;
     }
 
@@ -68,8 +69,8 @@ public class ForeignExchangeRateRestController extends AbstractRestController<Fo
     @GetMapping
     @PageableAsQueryParam
     @Operation(summary = "Отобразить все", description = "Отображает все загруженные в БД информацию по обменным курсам")
-    protected Page<ForeignExchangeRate> get(@Parameter(hidden = true)
-                                            Pageable pageable) {
+    public Page<ForeignExchangeRate> get(@Parameter(hidden = true)
+                                         Pageable pageable) {
         return super.get(pageable);
     }
 
@@ -81,7 +82,7 @@ public class ForeignExchangeRateRestController extends AbstractRestController<Fo
                                             String currencyPair) {
         return foreignExchangeRateRepository.findByPkCurrencyPairOrderByPkDateDesc(currencyPair)
                 .stream()
-                .map(converter::fromEntity)
+                .map(foreignExchangeRateConverter::fromEntity)
                 .collect(Collectors.toList());
     }
 
@@ -144,11 +145,6 @@ public class ForeignExchangeRateRestController extends AbstractRestController<Fo
     }
 
     @Override
-    protected Optional<ForeignExchangeRateEntity> getById(ForeignExchangeRateEntityPk id) {
-        return repository.findById(id);
-    }
-
-    @Override
     protected ForeignExchangeRateEntityPk getId(ForeignExchangeRate object) {
         return getId(object.getCurrencyPair(), object.getDate());
     }
@@ -169,7 +165,8 @@ public class ForeignExchangeRateRestController extends AbstractRestController<Fo
     }
 
     @Override
-    protected URI getLocationURI(ForeignExchangeRate object) throws URISyntaxException {
+    @SneakyThrows
+    protected URI getLocationURI(ForeignExchangeRate object) {
         return new URI(getLocation() + "/currency-pairs/" + object.getCurrencyPair() + "/dates/" + object.getDate());
     }
 

--- a/src/main/java/ru/investbook/api/IssuerRestController.java
+++ b/src/main/java/ru/investbook/api/IssuerRestController.java
@@ -88,10 +88,10 @@ public class IssuerRestController extends AbstractRestController<Integer, Issuer
     @Override
     @DeleteMapping("{id}")
     @Operation(summary = "Удалить", description = "Удаляет сведения об эмитенте из БД")
-    public void delete(@PathVariable("id")
+    public ResponseEntity<Void> delete(@PathVariable("id")
                        @Parameter(description = "Внутренний идентификатор эмитента")
                        Integer id) {
-        super.delete(id);
+        return super.delete(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/IssuerRestController.java
+++ b/src/main/java/ru/investbook/api/IssuerRestController.java
@@ -95,7 +95,7 @@ public class IssuerRestController extends AbstractRestController<Integer, Issuer
     }
 
     @Override
-    protected Integer getId(Issuer object) {
+    public Integer getId(Issuer object) {
         return object.getId();
     }
 

--- a/src/main/java/ru/investbook/api/IssuerRestController.java
+++ b/src/main/java/ru/investbook/api/IssuerRestController.java
@@ -39,8 +39,6 @@ import org.springframework.web.bind.annotation.RestController;
 import ru.investbook.converter.EntityConverter;
 import ru.investbook.entity.IssuerEntity;
 
-import java.util.Optional;
-
 @RestController
 @Tag(name = "Эмитенты", description = "Информация об эмитентах")
 @RequestMapping("/api/v1/issuers")
@@ -94,11 +92,6 @@ public class IssuerRestController extends AbstractRestController<Integer, Issuer
                        @Parameter(description = "Внутренний идентификатор эмитента")
                        Integer id) {
         super.delete(id);
-    }
-
-    @Override
-    protected Optional<IssuerEntity> getById(Integer id) {
-        return repository.findById(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/PortfolioCashRestController.java
+++ b/src/main/java/ru/investbook/api/PortfolioCashRestController.java
@@ -89,10 +89,10 @@ public class PortfolioCashRestController extends AbstractRestController<Integer,
     @Override
     @DeleteMapping("{id}")
     @Operation(summary = "Удалить")
-    public void delete(@PathVariable("id")
+    public ResponseEntity<Void> delete(@PathVariable("id")
                        @Parameter(description = "Внутренний идентификатор записи")
                        Integer id) {
-        super.delete(id);
+        return super.delete(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/PortfolioCashRestController.java
+++ b/src/main/java/ru/investbook/api/PortfolioCashRestController.java
@@ -39,8 +39,6 @@ import org.springframework.web.bind.annotation.RestController;
 import ru.investbook.converter.EntityConverter;
 import ru.investbook.entity.PortfolioCashEntity;
 
-import java.util.Optional;
-
 @RestController
 @Tag(name = "Информация по остатку денежных средств на счете")
 @RequestMapping("/api/v1/portfolio-cash")
@@ -95,11 +93,6 @@ public class PortfolioCashRestController extends AbstractRestController<Integer,
                        @Parameter(description = "Внутренний идентификатор записи")
                        Integer id) {
         super.delete(id);
-    }
-
-    @Override
-    protected Optional<PortfolioCashEntity> getById(Integer id) {
-        return repository.findById(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/PortfolioCashRestController.java
+++ b/src/main/java/ru/investbook/api/PortfolioCashRestController.java
@@ -96,7 +96,7 @@ public class PortfolioCashRestController extends AbstractRestController<Integer,
     }
 
     @Override
-    protected Integer getId(PortfolioCash object) {
+    public Integer getId(PortfolioCash object) {
         return object.getId();
     }
 

--- a/src/main/java/ru/investbook/api/PortfolioPropertyRestController.java
+++ b/src/main/java/ru/investbook/api/PortfolioPropertyRestController.java
@@ -39,8 +39,6 @@ import org.springframework.web.bind.annotation.RestController;
 import ru.investbook.converter.EntityConverter;
 import ru.investbook.entity.PortfolioPropertyEntity;
 
-import java.util.Optional;
-
 @RestController
 @Tag(name = "Информация по счетам")
 @RequestMapping("/api/v1/portfolio-properties")
@@ -95,11 +93,6 @@ public class PortfolioPropertyRestController extends AbstractRestController<Inte
                        @Parameter(description = "Внутренний идентификатор записи")
                        Integer id) {
         super.delete(id);
-    }
-
-    @Override
-    protected Optional<PortfolioPropertyEntity> getById(Integer id) {
-        return repository.findById(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/PortfolioPropertyRestController.java
+++ b/src/main/java/ru/investbook/api/PortfolioPropertyRestController.java
@@ -96,7 +96,7 @@ public class PortfolioPropertyRestController extends AbstractRestController<Inte
     }
 
     @Override
-    protected Integer getId(PortfolioProperty object) {
+    public Integer getId(PortfolioProperty object) {
         return object.getId();
     }
 

--- a/src/main/java/ru/investbook/api/PortfolioPropertyRestController.java
+++ b/src/main/java/ru/investbook/api/PortfolioPropertyRestController.java
@@ -89,10 +89,10 @@ public class PortfolioPropertyRestController extends AbstractRestController<Inte
     @Override
     @DeleteMapping("{id}")
     @Operation(summary = "Удалить")
-    public void delete(@PathVariable("id")
+    public ResponseEntity<Void> delete(@PathVariable("id")
                        @Parameter(description = "Внутренний идентификатор записи")
                        Integer id) {
-        super.delete(id);
+        return super.delete(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/PortfolioRestController.java
+++ b/src/main/java/ru/investbook/api/PortfolioRestController.java
@@ -97,7 +97,7 @@ public class PortfolioRestController extends AbstractRestController<String, Port
     }
 
     @Override
-    protected String getId(Portfolio object) {
+    public String getId(Portfolio object) {
         return object.getId();
     }
 

--- a/src/main/java/ru/investbook/api/PortfolioRestController.java
+++ b/src/main/java/ru/investbook/api/PortfolioRestController.java
@@ -39,8 +39,6 @@ import ru.investbook.converter.PortfolioConverter;
 import ru.investbook.entity.PortfolioEntity;
 import ru.investbook.repository.PortfolioRepository;
 
-import java.util.Optional;
-
 @RestController
 @Tag(name = "Счета")
 @RequestMapping("/api/v1/portfolios")
@@ -96,11 +94,6 @@ public class PortfolioRestController extends AbstractRestController<String, Port
                        @Parameter(description = "Номер счета")
                        String id) {
         super.delete(id);
-    }
-
-    @Override
-    protected Optional<PortfolioEntity> getById(String id) {
-        return repository.findById(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/PortfolioRestController.java
+++ b/src/main/java/ru/investbook/api/PortfolioRestController.java
@@ -90,10 +90,10 @@ public class PortfolioRestController extends AbstractRestController<String, Port
     @Override
     @DeleteMapping("{id}")
     @Operation(summary = "Удалить", description = "Удалить счет и все связанные с ним данные")
-    public void delete(@PathVariable("id")
+    public ResponseEntity<Void> delete(@PathVariable("id")
                        @Parameter(description = "Номер счета")
                        String id) {
-        super.delete(id);
+        return super.delete(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/SecurityDescriptionRestController.java
+++ b/src/main/java/ru/investbook/api/SecurityDescriptionRestController.java
@@ -101,7 +101,7 @@ public class SecurityDescriptionRestController extends AbstractRestController<In
     }
 
     @Override
-    protected Integer getId(SecurityDescription object) {
+    public Integer getId(SecurityDescription object) {
         return object.getSecurity();
     }
 

--- a/src/main/java/ru/investbook/api/SecurityDescriptionRestController.java
+++ b/src/main/java/ru/investbook/api/SecurityDescriptionRestController.java
@@ -94,10 +94,10 @@ public class SecurityDescriptionRestController extends AbstractRestController<In
     @Override
     @DeleteMapping("{id}")
     @Operation(summary = "Удалить", description = "Удалить информацию по инструменту")
-    public void delete(@PathVariable("id")
+    public ResponseEntity<Void> delete(@PathVariable("id")
                        @Parameter(description = "Идентификатор", example = "123", required = true)
                        Integer id) {
-        super.delete(id);
+        return super.delete(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/SecurityDescriptionRestController.java
+++ b/src/main/java/ru/investbook/api/SecurityDescriptionRestController.java
@@ -39,8 +39,6 @@ import ru.investbook.converter.SecurityDescriptionConverter;
 import ru.investbook.entity.SecurityDescriptionEntity;
 import ru.investbook.repository.SecurityDescriptionRepository;
 
-import java.util.Optional;
-
 @RestController
 @Tag(name = "Информация по инструментам", description = "Сектор экономики, эмитент")
 @RequestMapping("/api/v1/security-descriptions")
@@ -100,11 +98,6 @@ public class SecurityDescriptionRestController extends AbstractRestController<In
                        @Parameter(description = "Идентификатор", example = "123", required = true)
                        Integer id) {
         super.delete(id);
-    }
-
-    @Override
-    protected Optional<SecurityDescriptionEntity> getById(Integer isin) {
-        return repository.findById(isin);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/SecurityEventCashFlowRestController.java
+++ b/src/main/java/ru/investbook/api/SecurityEventCashFlowRestController.java
@@ -107,7 +107,7 @@ public class SecurityEventCashFlowRestController extends AbstractRestController<
     }
 
     @Override
-    protected Integer getId(SecurityEventCashFlow object) {
+    public Integer getId(SecurityEventCashFlow object) {
         return object.getId();
     }
 

--- a/src/main/java/ru/investbook/api/SecurityEventCashFlowRestController.java
+++ b/src/main/java/ru/investbook/api/SecurityEventCashFlowRestController.java
@@ -99,11 +99,11 @@ public class SecurityEventCashFlowRestController extends AbstractRestController<
     @Override
     @DeleteMapping("{id}")
     @Operation(summary = "Удалить", description = "Удалить информацию о выплате из БД")
-    public void delete(@PathVariable("id")
+    public ResponseEntity<Void> delete(@PathVariable("id")
                        @Parameter(description = "Внутренний идентификатор выплаты в БД")
                        Integer id) {
         positionsFactory.invalidateCache();
-        super.delete(id);
+        return super.delete(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/SecurityEventCashFlowRestController.java
+++ b/src/main/java/ru/investbook/api/SecurityEventCashFlowRestController.java
@@ -40,8 +40,6 @@ import ru.investbook.converter.EntityConverter;
 import ru.investbook.entity.SecurityEventCashFlowEntity;
 import ru.investbook.report.FifoPositionsFactory;
 
-import java.util.Optional;
-
 import static org.spacious_team.broker.pojo.CashFlowType.REDEMPTION;
 
 @RestController
@@ -106,11 +104,6 @@ public class SecurityEventCashFlowRestController extends AbstractRestController<
                        Integer id) {
         positionsFactory.invalidateCache();
         super.delete(id);
-    }
-
-    @Override
-    protected Optional<SecurityEventCashFlowEntity> getById(Integer id) {
-        return repository.findById(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/SecurityQuoteRestController.java
+++ b/src/main/java/ru/investbook/api/SecurityQuoteRestController.java
@@ -39,8 +39,6 @@ import org.springframework.web.bind.annotation.RestController;
 import ru.investbook.converter.EntityConverter;
 import ru.investbook.entity.SecurityQuoteEntity;
 
-import java.util.Optional;
-
 @RestController
 @Tag(name = "Котировки", description = "Котировки биржевых инструментов")
 @RequestMapping("/api/v1/security-quotes")
@@ -96,11 +94,6 @@ public class SecurityQuoteRestController extends AbstractRestController<Integer,
                        @Parameter(description = "Номер записи о котировке")
                        Integer id) {
         super.delete(id);
-    }
-
-    @Override
-    protected Optional<SecurityQuoteEntity> getById(Integer id) {
-        return repository.findById(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/SecurityQuoteRestController.java
+++ b/src/main/java/ru/investbook/api/SecurityQuoteRestController.java
@@ -90,10 +90,10 @@ public class SecurityQuoteRestController extends AbstractRestController<Integer,
     @Override
     @DeleteMapping("{id}")
     @Operation(summary = "Удалить")
-    public void delete(@PathVariable("id")
+    public ResponseEntity<Void> delete(@PathVariable("id")
                        @Parameter(description = "Номер записи о котировке")
                        Integer id) {
-        super.delete(id);
+        return super.delete(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/SecurityQuoteRestController.java
+++ b/src/main/java/ru/investbook/api/SecurityQuoteRestController.java
@@ -97,7 +97,7 @@ public class SecurityQuoteRestController extends AbstractRestController<Integer,
     }
 
     @Override
-    protected Integer getId(SecurityQuote object) {
+    public Integer getId(SecurityQuote object) {
         return object.getId();
     }
 

--- a/src/main/java/ru/investbook/api/SecurityRestController.java
+++ b/src/main/java/ru/investbook/api/SecurityRestController.java
@@ -65,7 +65,7 @@ public class SecurityRestController extends AbstractRestController<Integer, Secu
     @Override
     @GetMapping("{id}")
     @Operation(summary = "Отобразить один",
-            description = "Отобразить биржевой инструмент по идентификатору (ISIN,  коду дериватива, валютной пары)")
+            description = "Отобразить биржевой инструмент по внутреннему идентификатору")
     public ResponseEntity<Security> get(@PathVariable("id")
                                         @Parameter(description = "Идентификатор", example = "123", required = true)
                                         Integer id) {
@@ -102,8 +102,8 @@ public class SecurityRestController extends AbstractRestController<Integer, Secu
     }
 
     @Override
-    protected Optional<SecurityEntity> getById(Integer isin) {
-        return repository.findById(isin);
+    protected Optional<SecurityEntity> getById(Integer id) {
+        return repository.findById(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/SecurityRestController.java
+++ b/src/main/java/ru/investbook/api/SecurityRestController.java
@@ -39,8 +39,6 @@ import ru.investbook.converter.SecurityConverter;
 import ru.investbook.entity.SecurityEntity;
 import ru.investbook.repository.SecurityRepository;
 
-import java.util.Optional;
-
 @RestController
 @Tag(name = "Инструменты", description = "Акции, облигации, деривативы и валютные пары")
 @RequestMapping("/api/v1/securities")
@@ -99,11 +97,6 @@ public class SecurityRestController extends AbstractRestController<Integer, Secu
                        @Parameter(description = "Идентификатор", example = "123", required = true)
                        Integer id) {
         super.delete(id);
-    }
-
-    @Override
-    protected Optional<SecurityEntity> getById(Integer id) {
-        return repository.findById(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/SecurityRestController.java
+++ b/src/main/java/ru/investbook/api/SecurityRestController.java
@@ -93,10 +93,10 @@ public class SecurityRestController extends AbstractRestController<Integer, Secu
     @Override
     @DeleteMapping("{id}")
     @Operation(summary = "Удалить", description = "Удалить сведения о биржевом инструменте и всех его сделках по всем счетам")
-    public void delete(@PathVariable("id")
+    public ResponseEntity<Void> delete(@PathVariable("id")
                        @Parameter(description = "Идентификатор", example = "123", required = true)
                        Integer id) {
-        super.delete(id);
+        return super.delete(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/SecurityRestController.java
+++ b/src/main/java/ru/investbook/api/SecurityRestController.java
@@ -100,7 +100,7 @@ public class SecurityRestController extends AbstractRestController<Integer, Secu
     }
 
     @Override
-    protected Integer getId(Security object) {
+    public Integer getId(Security object) {
         return object.getId();
     }
 

--- a/src/main/java/ru/investbook/api/TransactionCashFlowRestController.java
+++ b/src/main/java/ru/investbook/api/TransactionCashFlowRestController.java
@@ -44,7 +44,6 @@ import ru.investbook.entity.TransactionCashFlowEntity;
 import ru.investbook.repository.TransactionCashFlowRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 @Tag(name = "Движения ДС по сделкам", description = "Уплаченные и вырученные суммы в сделках")
@@ -142,11 +141,6 @@ public class TransactionCashFlowRestController extends AbstractRestController<In
                        @Parameter(description = "Внутренний идентификатор сделки")
                        Integer id) {
         super.delete(id);
-    }
-
-    @Override
-    protected Optional<TransactionCashFlowEntity> getById(Integer id) {
-        return repository.findById(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/TransactionCashFlowRestController.java
+++ b/src/main/java/ru/investbook/api/TransactionCashFlowRestController.java
@@ -144,7 +144,7 @@ public class TransactionCashFlowRestController extends AbstractRestController<In
     }
 
     @Override
-    protected Integer getId(TransactionCashFlow object) {
+    public Integer getId(TransactionCashFlow object) {
         return object.getId();
     }
 

--- a/src/main/java/ru/investbook/api/TransactionCashFlowRestController.java
+++ b/src/main/java/ru/investbook/api/TransactionCashFlowRestController.java
@@ -137,10 +137,10 @@ public class TransactionCashFlowRestController extends AbstractRestController<In
     @Operation(summary = "Удалить", description = """
             Удалить информацию об об объемах движения ДС по сделке. Сама сделка не удаляется, ее нужно удалить своим API
             """)
-    public void delete(@PathVariable("id")
+    public ResponseEntity<Void> delete(@PathVariable("id")
                        @Parameter(description = "Внутренний идентификатор сделки")
                        Integer id) {
-        super.delete(id);
+        return super.delete(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/TransactionRestController.java
+++ b/src/main/java/ru/investbook/api/TransactionRestController.java
@@ -151,7 +151,7 @@ public class TransactionRestController extends AbstractRestController<Integer, T
     }
 
     @Override
-    protected Integer getId(Transaction object) {
+    public Integer getId(Transaction object) {
         return object.getId();
     }
 

--- a/src/main/java/ru/investbook/api/TransactionRestController.java
+++ b/src/main/java/ru/investbook/api/TransactionRestController.java
@@ -43,7 +43,6 @@ import ru.investbook.report.FifoPositionsFactory;
 import ru.investbook.repository.TransactionRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 @Tag(name = "Сделки", description = "Операции купли/продажи биржевых инструментов")
@@ -149,11 +148,6 @@ public class TransactionRestController extends AbstractRestController<Integer, T
                        Integer id) {
         positionsFactory.invalidateCache();
         super.delete(id);
-    }
-
-    @Override
-    protected Optional<TransactionEntity> getById(Integer id) {
-        return repository.findById(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/api/TransactionRestController.java
+++ b/src/main/java/ru/investbook/api/TransactionRestController.java
@@ -143,11 +143,11 @@ public class TransactionRestController extends AbstractRestController<Integer, T
     @Override
     @DeleteMapping("{id}")
     @Operation(summary = "Удалить", description = "Удаляет указанную сделку")
-    public void delete(@PathVariable("id")
+    public ResponseEntity<Void> delete(@PathVariable("id")
                        @Parameter(description = "Внутренний идентификатор сделки")
                        Integer id) {
         positionsFactory.invalidateCache();
-        super.delete(id);
+        return super.delete(id);
     }
 
     @Override

--- a/src/main/java/ru/investbook/converter/EventCashFlowConverter.java
+++ b/src/main/java/ru/investbook/converter/EventCashFlowConverter.java
@@ -36,10 +36,8 @@ public class EventCashFlowConverter implements EntityConverter<EventCashFlowEnti
 
     @Override
     public EventCashFlowEntity toEntity(EventCashFlow eventCashFlow) {
-        PortfolioEntity portfolioEntity = portfolioRepository.findById(eventCashFlow.getPortfolio())
-                .orElseThrow(() -> new IllegalArgumentException("В справочнике не найден брокерский счет: " + eventCashFlow.getPortfolio()));
-        CashFlowTypeEntity cashFlowTypeEntity = cashFlowTypeRepository.findById(eventCashFlow.getEventType().getId())
-                .orElseThrow(() -> new IllegalArgumentException("В справочнике не найдено событие с типом: " + eventCashFlow.getEventType().getId()));
+        PortfolioEntity portfolioEntity = portfolioRepository.getReferenceById(eventCashFlow.getPortfolio());
+        CashFlowTypeEntity cashFlowTypeEntity = cashFlowTypeRepository.getReferenceById(eventCashFlow.getEventType().getId());
 
         EventCashFlowEntity entity = new EventCashFlowEntity();
         entity.setId(eventCashFlow.getId());

--- a/src/main/java/ru/investbook/converter/PortfolioPropertyConverter.java
+++ b/src/main/java/ru/investbook/converter/PortfolioPropertyConverter.java
@@ -33,8 +33,7 @@ public class PortfolioPropertyConverter implements EntityConverter<PortfolioProp
 
     @Override
     public PortfolioPropertyEntity toEntity(PortfolioProperty property) {
-        PortfolioEntity portfolioEntity = portfolioRepository.findById(property.getPortfolio())
-                .orElseThrow(() -> new IllegalArgumentException("В справочнике не найден брокерский счет: " + property.getPortfolio()));
+        PortfolioEntity portfolioEntity = portfolioRepository.getReferenceById(property.getPortfolio());
 
         PortfolioPropertyEntity entity = new PortfolioPropertyEntity();
         entity.setId(property.getId());

--- a/src/main/java/ru/investbook/converter/SecurityDescriptionConverter.java
+++ b/src/main/java/ru/investbook/converter/SecurityDescriptionConverter.java
@@ -35,8 +35,7 @@ public class SecurityDescriptionConverter implements EntityConverter<SecurityDes
     public SecurityDescriptionEntity toEntity(SecurityDescription security) {
         IssuerEntity issuerEntity = null;
         if (security.getIssuer() != null) {
-            issuerEntity = issuerRepository.findById(security.getIssuer())
-                    .orElseThrow(() -> new IllegalArgumentException("Эмитент c идентификатором не найден: " + security.getIssuer()));
+            issuerEntity = issuerRepository.getReferenceById(security.getIssuer());
         }
 
         SecurityDescriptionEntity entity = new SecurityDescriptionEntity();

--- a/src/main/java/ru/investbook/converter/SecurityEventCashFlowConverter.java
+++ b/src/main/java/ru/investbook/converter/SecurityEventCashFlowConverter.java
@@ -39,12 +39,9 @@ public class SecurityEventCashFlowConverter implements EntityConverter<SecurityE
 
     @Override
     public SecurityEventCashFlowEntity toEntity(SecurityEventCashFlow eventCashFlow) {
-        SecurityEntity securityEntity = securityRepository.findById(eventCashFlow.getSecurity())
-                .orElseThrow(() -> new IllegalArgumentException("Ценная бумага с заданным ID не найдена: " + eventCashFlow.getSecurity()));
-        PortfolioEntity portfolioEntity = portfolioRepository.findById(eventCashFlow.getPortfolio())
-                .orElseThrow(() -> new IllegalArgumentException("В справочнике не найден брокерский счет: " + eventCashFlow.getPortfolio()));
-        CashFlowTypeEntity cashFlowTypeEntity = cashFlowTypeRepository.findById(eventCashFlow.getEventType().getId())
-                .orElseThrow(() -> new IllegalArgumentException("В справочнике не найдено событие с типом: " + eventCashFlow.getEventType().getId()));
+        SecurityEntity securityEntity = securityRepository.getReferenceById(eventCashFlow.getSecurity());
+        PortfolioEntity portfolioEntity = portfolioRepository.getReferenceById(eventCashFlow.getPortfolio());
+        CashFlowTypeEntity cashFlowTypeEntity = cashFlowTypeRepository.getReferenceById(eventCashFlow.getEventType().getId());
 
         SecurityEventCashFlowEntity entity = new SecurityEventCashFlowEntity();
         entity.setId(eventCashFlow.getId());

--- a/src/main/java/ru/investbook/converter/SecurityQuoteConverter.java
+++ b/src/main/java/ru/investbook/converter/SecurityQuoteConverter.java
@@ -32,9 +32,7 @@ public class SecurityQuoteConverter implements EntityConverter<SecurityQuoteEnti
 
     @Override
     public SecurityQuoteEntity toEntity(SecurityQuote quote) {
-        SecurityEntity securityEntity = securityRepository.findById(quote.getSecurity())
-                .orElseThrow(() -> new IllegalArgumentException("Ценная бумага с заданным ISIN не найдена: " + quote.getSecurity()));
-
+        SecurityEntity securityEntity = securityRepository.getReferenceById(quote.getSecurity());
 
         SecurityQuoteEntity entity = new SecurityQuoteEntity();
         entity.setId(quote.getId());

--- a/src/main/java/ru/investbook/converter/TransactionCashFlowConverter.java
+++ b/src/main/java/ru/investbook/converter/TransactionCashFlowConverter.java
@@ -35,11 +35,7 @@ public class TransactionCashFlowConverter implements EntityConverter<Transaction
 
     @Override
     public TransactionCashFlowEntity toEntity(TransactionCashFlow cash) {
-        if (!transactionRepository.existsById(cash.getTransactionId())) {
-            throw new IllegalArgumentException("Транзакция с номером не найдена: " + cash.getTransactionId());
-        }
-        CashFlowTypeEntity cashFlowTypeEntity = cashFlowTypeRepository.findById(cash.getEventType().getId())
-                .orElseThrow(() -> new IllegalArgumentException("В справочнике не найдено событие с типом: " + cash.getEventType().getId()));
+        CashFlowTypeEntity cashFlowTypeEntity = cashFlowTypeRepository.getReferenceById(cash.getEventType().getId());
 
         TransactionCashFlowEntity entity = new TransactionCashFlowEntity();
         entity.setId(cash.getId());

--- a/src/main/java/ru/investbook/converter/TransactionConverter.java
+++ b/src/main/java/ru/investbook/converter/TransactionConverter.java
@@ -23,21 +23,16 @@ import org.spacious_team.broker.pojo.Transaction;
 import org.springframework.stereotype.Component;
 import ru.investbook.entity.SecurityEntity;
 import ru.investbook.entity.TransactionEntity;
-import ru.investbook.repository.PortfolioRepository;
 import ru.investbook.repository.SecurityRepository;
 
 @Component
 @RequiredArgsConstructor
 public class TransactionConverter implements EntityConverter<TransactionEntity, Transaction> {
-    private final PortfolioRepository portfolioRepository;
     private final SecurityRepository securityRepository;
 
     @Override
     public TransactionEntity toEntity(Transaction transaction) {
-        portfolioRepository.findById(transaction.getPortfolio())
-                .orElseThrow(() -> new IllegalArgumentException("В справочнике не найден брокерский счет: " + transaction.getPortfolio()));
-        SecurityEntity securityEntity = securityRepository.findById(transaction.getSecurity())
-                .orElseThrow(() -> new IllegalArgumentException("Ценная бумага с заданным ID не найдена: " + transaction.getSecurity()));
+        SecurityEntity securityEntity = securityRepository.getReferenceById(transaction.getSecurity());
 
         TransactionEntity entity = new TransactionEntity();
         entity.setId(transaction.getId());

--- a/src/main/java/ru/investbook/entity/CashFlowTypeEntity.java
+++ b/src/main/java/ru/investbook/entity/CashFlowTypeEntity.java
@@ -30,10 +30,10 @@ import lombok.Data;
 @Data
 public class CashFlowTypeEntity {
     @Id
-    @Column(name = "id")
+    @Column(name = "id", nullable = false)
     private int id;
 
     @Basic
-    @Column(name = "name")
+    @Column(name = "name", nullable = false)
     private String name;
 }

--- a/src/main/java/ru/investbook/entity/EventCashFlowEntity.java
+++ b/src/main/java/ru/investbook/entity/EventCashFlowEntity.java
@@ -59,11 +59,11 @@ public class EventCashFlowEntity {
     private CashFlowTypeEntity cashFlowType;
 
     @Basic
-    @Column(name = "value")
+    @Column(name = "value", nullable = false)
     private BigDecimal value;
 
     @Basic
-    @Column(name = "currency")
+    @Column(name = "currency", nullable = false)
     private String currency = "RUR";
 
     @Basic

--- a/src/main/java/ru/investbook/entity/EventCashFlowEntity.java
+++ b/src/main/java/ru/investbook/entity/EventCashFlowEntity.java
@@ -44,8 +44,8 @@ public class EventCashFlowEntity {
     @Column(name = "id")
     private Integer id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "portfolio", referencedColumnName = "id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "portfolio", referencedColumnName = "id", nullable = false)
     @JsonIgnoreProperties({"hibernateLazyInitializer"})
     private PortfolioEntity portfolio;
 
@@ -53,8 +53,8 @@ public class EventCashFlowEntity {
     @Column(name = "timestamp")
     private Instant timestamp;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "type", referencedColumnName = "id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "type", referencedColumnName = "id", nullable = false)
     @JsonIgnoreProperties({"hibernateLazyInitializer"})
     private CashFlowTypeEntity cashFlowType;
 

--- a/src/main/java/ru/investbook/entity/ForeignExchangeRateEntity.java
+++ b/src/main/java/ru/investbook/entity/ForeignExchangeRateEntity.java
@@ -36,6 +36,6 @@ public class ForeignExchangeRateEntity {
     private ForeignExchangeRateEntityPk pk;
 
     @Basic
-    @Column(name = "rate")
+    @Column(name = "rate", nullable = false)
     private BigDecimal rate;
 }

--- a/src/main/java/ru/investbook/entity/ForeignExchangeRateEntityPk.java
+++ b/src/main/java/ru/investbook/entity/ForeignExchangeRateEntityPk.java
@@ -32,10 +32,10 @@ import java.time.LocalDate;
 @Data
 public class ForeignExchangeRateEntityPk implements Serializable {
 
-    @Column(name = "date")
+    @Column(name = "date", nullable = false)
     private LocalDate date;
 
     @Basic
-    @Column(name = "currency_pair")
+    @Column(name = "currency_pair", nullable = false)
     private String currencyPair;
 }

--- a/src/main/java/ru/investbook/entity/PortfolioEntity.java
+++ b/src/main/java/ru/investbook/entity/PortfolioEntity.java
@@ -33,10 +33,10 @@ import lombok.EqualsAndHashCode;
 public class PortfolioEntity {
 
     @Id
-    @Column(name = "id")
+    @Column(name = "id", nullable = false)
     private String id;
 
     @Basic
-    @Column(name = "enabled")
+    @Column(name = "enabled", nullable = false)
     private boolean enabled;
 }

--- a/src/main/java/ru/investbook/entity/PortfolioPropertyEntity.java
+++ b/src/main/java/ru/investbook/entity/PortfolioPropertyEntity.java
@@ -41,8 +41,8 @@ public class PortfolioPropertyEntity {
     @Column(name = "id")
     private Integer id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "portfolio", referencedColumnName = "id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "portfolio", referencedColumnName = "id", nullable = false)
     @JsonIgnoreProperties({"hibernateLazyInitializer"})
     private PortfolioEntity portfolio;
 

--- a/src/main/java/ru/investbook/entity/PortfolioPropertyEntity.java
+++ b/src/main/java/ru/investbook/entity/PortfolioPropertyEntity.java
@@ -47,14 +47,14 @@ public class PortfolioPropertyEntity {
     private PortfolioEntity portfolio;
 
     @Basic
-    @Column(name = "timestamp")
+    @Column(name = "timestamp", nullable = false)
     private Instant timestamp;
 
     @Basic
-    @Column(name = "property")
+    @Column(name = "property", nullable = false)
     private String property;
 
     @Basic
-    @Column(name = "value")
+    @Column(name = "value", nullable = false)
     private String value;
 }

--- a/src/main/java/ru/investbook/entity/SecurityDescriptionEntity.java
+++ b/src/main/java/ru/investbook/entity/SecurityDescriptionEntity.java
@@ -35,7 +35,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(of = "security")
 public class SecurityDescriptionEntity {
     @Id
-    @Column(name = "security")
+    @Column(name = "security", nullable = false)
     private int security;
 
     @Column(name = "sector")

--- a/src/main/java/ru/investbook/entity/SecurityEventCashFlowEntity.java
+++ b/src/main/java/ru/investbook/entity/SecurityEventCashFlowEntity.java
@@ -50,7 +50,7 @@ public class SecurityEventCashFlowEntity {
     private PortfolioEntity portfolio;
 
     @Basic
-    @Column(name = "timestamp")
+    @Column(name = "timestamp", nullable = false)
     private Instant timestamp;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -59,7 +59,7 @@ public class SecurityEventCashFlowEntity {
     private SecurityEntity security;
 
     @Basic
-    @Column(name = "count")
+    @Column(name = "count", nullable = false)
     private Integer count;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -68,10 +68,10 @@ public class SecurityEventCashFlowEntity {
     private CashFlowTypeEntity cashFlowType;
 
     @Basic
-    @Column(name = "value")
+    @Column(name = "value", nullable = false)
     private BigDecimal value;
 
     @Basic
-    @Column(name = "currency")
+    @Column(name = "currency", nullable = false)
     private String currency = "RUR";
 }

--- a/src/main/java/ru/investbook/entity/SecurityEventCashFlowEntity.java
+++ b/src/main/java/ru/investbook/entity/SecurityEventCashFlowEntity.java
@@ -44,8 +44,8 @@ public class SecurityEventCashFlowEntity {
     @Column(name = "id")
     private Integer id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "portfolio", referencedColumnName = "id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "portfolio", referencedColumnName = "id", nullable = false)
     @JsonIgnoreProperties({"hibernateLazyInitializer"})
     private PortfolioEntity portfolio;
 
@@ -53,8 +53,8 @@ public class SecurityEventCashFlowEntity {
     @Column(name = "timestamp")
     private Instant timestamp;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "security", referencedColumnName = "id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "security", referencedColumnName = "id", nullable = false)
     @JsonIgnoreProperties({"hibernateLazyInitializer"})
     private SecurityEntity security;
 
@@ -62,8 +62,8 @@ public class SecurityEventCashFlowEntity {
     @Column(name = "count")
     private Integer count;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "type", referencedColumnName = "id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "type", referencedColumnName = "id", nullable = false)
     @JsonIgnoreProperties({"hibernateLazyInitializer"})
     private CashFlowTypeEntity cashFlowType;
 

--- a/src/main/java/ru/investbook/entity/SecurityQuoteEntity.java
+++ b/src/main/java/ru/investbook/entity/SecurityQuoteEntity.java
@@ -48,11 +48,11 @@ public class SecurityQuoteEntity {
     private SecurityEntity security;
 
     @Basic
-    @Column(name = "timestamp")
+    @Column(name = "timestamp", nullable = false)
     private Instant timestamp;
 
     @Basic
-    @Column(name = "quote")
+    @Column(name = "quote", nullable = false)
     private BigDecimal quote;
 
     @Basic

--- a/src/main/java/ru/investbook/entity/SecurityQuoteEntity.java
+++ b/src/main/java/ru/investbook/entity/SecurityQuoteEntity.java
@@ -42,8 +42,8 @@ public class SecurityQuoteEntity {
     @Column(name = "id")
     private Integer id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "security", referencedColumnName = "id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "security", referencedColumnName = "id", nullable = false)
     @JsonIgnoreProperties({"hibernateLazyInitializer"})
     private SecurityEntity security;
 

--- a/src/main/java/ru/investbook/entity/StockMarketIndexEntity.java
+++ b/src/main/java/ru/investbook/entity/StockMarketIndexEntity.java
@@ -41,6 +41,7 @@ import java.time.LocalDate;
 public class StockMarketIndexEntity {
 
     @Id
+    @Column(name = "date", nullable = false)
     private LocalDate date;
 
     @Basic

--- a/src/main/java/ru/investbook/entity/TransactionCashFlowEntity.java
+++ b/src/main/java/ru/investbook/entity/TransactionCashFlowEntity.java
@@ -45,7 +45,7 @@ public class TransactionCashFlowEntity {
     @Column(name = "transaction_id")
     private int transactionId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "type", referencedColumnName = "id", nullable = false)
     private CashFlowTypeEntity cashFlowType;
 
@@ -61,7 +61,7 @@ public class TransactionCashFlowEntity {
     /*
     Nowadays not used, commented due to perf issue
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumns({
             @JoinColumn(name = "transaction_id", referencedColumnName = "id", insertable = false, updatable = false),
             @JoinColumn(name = "portfolio", referencedColumnName = "portfolio", insertable = false, updatable = false)

--- a/src/main/java/ru/investbook/entity/TransactionCashFlowEntity.java
+++ b/src/main/java/ru/investbook/entity/TransactionCashFlowEntity.java
@@ -42,7 +42,7 @@ public class TransactionCashFlowEntity {
     private Integer id;
 
     @Basic(optional = false)
-    @Column(name = "transaction_id")
+    @Column(name = "transaction_id", nullable = false)
     private int transactionId;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -50,11 +50,11 @@ public class TransactionCashFlowEntity {
     private CashFlowTypeEntity cashFlowType;
 
     @Basic(optional = false)
-    @Column(name = "value")
+    @Column(name = "value", nullable = false)
     private BigDecimal value;
 
     @Basic(optional = false)
-    @Column(name = "currency")
+    @Column(name = "currency", nullable = false)
     private String currency = "RUR";
 
 

--- a/src/main/java/ru/investbook/entity/TransactionEntity.java
+++ b/src/main/java/ru/investbook/entity/TransactionEntity.java
@@ -53,13 +53,14 @@ public class TransactionEntity {
     @Column(name = "portfolio")
     private String portfolio;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "portfolio", referencedColumnName = "id")
+//    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+//    @JoinColumn(name = "portfolio", referencedColumnName = "id", nullable = false)
 //    @JsonIgnoreProperties({"hibernateLazyInitializer"})
 //    private PortfolioEntity portfolio;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "security", referencedColumnName = "id")
+    // https://stackoverflow.com/questions/17987638/hibernate-one-to-one-lazy-loading-optional-false
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "security", referencedColumnName = "id", nullable = false)
     @JsonIgnoreProperties({"hibernateLazyInitializer"})
     private SecurityEntity security;
 

--- a/src/main/java/ru/investbook/entity/TransactionEntity.java
+++ b/src/main/java/ru/investbook/entity/TransactionEntity.java
@@ -46,11 +46,11 @@ public class TransactionEntity {
     private Integer id;
 
     @Basic(optional = false)
-    @Column(name = "trade_id")
+    @Column(name = "trade_id", nullable = false)
     private String tradeId;
 
     @Basic(optional = false)
-    @Column(name = "portfolio")
+    @Column(name = "portfolio", nullable = false)
     private String portfolio;
 
 //    @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -65,11 +65,11 @@ public class TransactionEntity {
     private SecurityEntity security;
 
     @Basic(optional = false)
-    @Column(name = "timestamp")
+    @Column(name = "timestamp", nullable = false)
     private Instant timestamp;
 
     @Basic(optional = false)
-    @Column(name = "count")
+    @Column(name = "count", nullable = false)
     private int count;
 
     /*

--- a/src/main/java/ru/investbook/parser/InvestbookApiClient.java
+++ b/src/main/java/ru/investbook/parser/InvestbookApiClient.java
@@ -120,6 +120,7 @@ public class InvestbookApiClient {
     }
 
     private Optional<Integer> getSavedTransactionId(AbstractTransaction transaction) {
+        // todo replace RestController with EntityRepositoryService
         return Optional.of(transactionRestController.get(transaction.getPortfolio(), transaction.getTradeId(), Pageable.unpaged()).getContent())
                 .filter(result -> result.size() == 1)
                 .map(List::getFirst)
@@ -196,6 +197,7 @@ public class InvestbookApiClient {
     /**
      * @return true if new row was added, or it was already exists in DB, false - or error
      */
+    // todo replace RestController with EntityRepositoryService
     private <T> boolean handlePost(T object, Function<T, ResponseEntity<?>> saver, String errorPrefix) {
         try {
             validator.validate(object);

--- a/src/main/java/ru/investbook/parser/InvestbookApiClient.java
+++ b/src/main/java/ru/investbook/parser/InvestbookApiClient.java
@@ -217,7 +217,8 @@ public class InvestbookApiClient {
             validator.validate(object);
             CreateResult<T> result = persistFunction.apply(object);
             return Optional.of(result.object());
-        } catch (Exception e) {  // jakarta.validation, not SQL constraint
+        } catch (Exception e) {
+            // should not be thrown for duplicate
             log.warn("{} {}: {}", errorMsg, object, e.getMessage());
             return Optional.empty();
         }

--- a/src/main/java/ru/investbook/parser/SecurityRegistrarImpl.java
+++ b/src/main/java/ru/investbook/parser/SecurityRegistrarImpl.java
@@ -127,7 +127,7 @@ public class SecurityRegistrarImpl implements SecurityRegistrar {
         return repository.findByIsin(isin)
                 .or(() -> Optional.of(supplier.get())
                         .map(builder -> buildSecurity(builder, defaultType))
-                        .map(security -> saveAndFlush(security, () -> repository.findByIsin(isin))))
+                        .map(security -> save(security, () -> repository.findByIsin(isin))))
                 .map(SecurityEntity::getId)
                 .orElseThrow(() -> new RuntimeException("Не смог сохранить ЦБ с ISIN = " + isin));
     }
@@ -136,7 +136,7 @@ public class SecurityRegistrarImpl implements SecurityRegistrar {
         return repository.findByName(name)
                 .or(() -> Optional.of(supplier.get())
                         .map(builder -> buildSecurity(builder, defaultType))
-                        .map(security -> saveAndFlush(security, () -> repository.findByName(name))))
+                        .map(security -> save(security, () -> repository.findByName(name))))
                 .map(SecurityEntity::getId)
                 .orElseThrow(() -> new RuntimeException("Не смог сохранить актив с наименованием = " + name));
     }
@@ -145,7 +145,7 @@ public class SecurityRegistrarImpl implements SecurityRegistrar {
         return repository.findByTicker(ticker)
                 .or(() -> Optional.of(supplier.get())
                         .map(builder -> buildSecurity(builder, defaultType))
-                        .map(security -> saveAndFlush(security, () -> repository.findByTicker(ticker))))
+                        .map(security -> save(security, () -> repository.findByTicker(ticker))))
                 .map(SecurityEntity::getId)
                 .orElseThrow(() -> new RuntimeException("Не смог сохранить актив с тикером = " + ticker));
     }
@@ -153,7 +153,7 @@ public class SecurityRegistrarImpl implements SecurityRegistrar {
     private Integer declareContractByTicker(String contract, SecurityType contractType) {
         return repository.findByTicker(contract)
                 .or(() -> Optional.of(Security.builder().ticker(contract).type(contractType).build())
-                        .map(security -> saveAndFlush(security, () -> repository.findByTicker(contract))))
+                        .map(security -> save(security, () -> repository.findByTicker(contract))))
                 .map(SecurityEntity::getId)
                 .orElseThrow(() -> new RuntimeException("Не смог сохранить контракт = " + contract));
     }
@@ -166,10 +166,10 @@ public class SecurityRegistrarImpl implements SecurityRegistrar {
         return security;
     }
 
-    private SecurityEntity saveAndFlush(Security security, Supplier<Optional<SecurityEntity>> supplier) {
+    private SecurityEntity save(Security security, Supplier<Optional<SecurityEntity>> supplier) {
         try {
             validator.validate(security);
-            return repository.saveAndFlush(converter.toEntity(security));
+            return repository.save(converter.toEntity(security));
         } catch (ConstraintViolationException e) {
             throw new RuntimeException("Не смог сохранить ценную бумагу в БД: " + security + ", " + e.getMessage());
         } catch (Exception e) {

--- a/src/main/java/ru/investbook/parser/investbook/AbstractSecurityAwareInvestbookTable.java
+++ b/src/main/java/ru/investbook/parser/investbook/AbstractSecurityAwareInvestbookTable.java
@@ -86,7 +86,7 @@ public class AbstractSecurityAwareInvestbookTable<RowType> extends AbstractInves
         } else {
             builder.name(securityTickerNameOrIsin);
         }
-        return securityRepository.saveAndFlush(securityConverter.toEntity(builder.build()));
+        return securityRepository.save(securityConverter.toEntity(builder.build()));
     }
 
     protected String getTradeId(String portfolio, int securityId, Instant instant) {

--- a/src/main/java/ru/investbook/parser/investbook/InvestbookSecurityDepositAndWithdrawalTable.java
+++ b/src/main/java/ru/investbook/parser/investbook/InvestbookSecurityDepositAndWithdrawalTable.java
@@ -78,6 +78,6 @@ public class InvestbookSecurityDepositAndWithdrawalTable extends AbstractSecurit
                 .type(SecurityType.STOCK_OR_BOND)
                 .name(securityTickerNameOrIsin)
                 .build();
-        return securityRepository.saveAndFlush(securityConverter.toEntity(security));
+        return securityRepository.save(securityConverter.toEntity(security));
     }
 }

--- a/src/main/java/ru/investbook/repository/ConstraintAwareRepository.java
+++ b/src/main/java/ru/investbook/repository/ConstraintAwareRepository.java
@@ -1,0 +1,41 @@
+/*
+ * InvestBook
+ * Copyright (C) 2024  Spacious Team <spacious-team@ya.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ru.investbook.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+
+import java.util.Optional;
+
+/**
+ * JpaRepository that knows about UNIQUE KEYS
+ */
+@NoRepositoryBean
+public interface ConstraintAwareRepository<T, ID> extends JpaRepository<T, ID> {
+
+    /**
+     * Checks entity existence by UNIQUE KEY fields, other fields is ignored
+     */
+    boolean exists(T probe);
+
+    /**
+     * Selects entity by UNIQUE KEY fields, other fields is ignored
+     */
+    Optional<T> findBy(T probe);
+}

--- a/src/main/java/ru/investbook/repository/TransactionRepository.java
+++ b/src/main/java/ru/investbook/repository/TransactionRepository.java
@@ -38,7 +38,8 @@ import java.util.Set;
 @Transactional(readOnly = true)
 public interface TransactionRepository extends
         JpaRepository<TransactionEntity, Integer>,
-        JpaSpecificationExecutor<TransactionEntity> {
+        JpaSpecificationExecutor<TransactionEntity>,
+        ConstraintAwareRepository<TransactionEntity, Integer> {
 
     Optional<TransactionEntity> findFirstByOrderByTimestampAsc();
 
@@ -336,4 +337,18 @@ public interface TransactionRepository extends
             @Param("to") Instant toDate);
 
     int countByPortfolioIn(Set<String> portfolio);
+
+    @Override
+    default boolean exists(TransactionEntity probe) {
+        return countByIdOrPortfolioAndTradeId(probe.getId(), probe.getPortfolio(), probe.getTradeId()) > 0;
+    }
+
+    long countByIdOrPortfolioAndTradeId(Integer id, String portfolio, String tradeId);
+
+    @Override
+    default Optional<TransactionEntity> findBy(TransactionEntity probe) {
+        return findByIdOrPortfolioAndTradeId(probe.getId(), probe.getPortfolio(), probe.getTradeId());
+    }
+
+    Optional<TransactionEntity> findByIdOrPortfolioAndTradeId(Integer id, String portfolio, String tradeId);
 }

--- a/src/main/java/ru/investbook/service/cbr/AbstractCbrForeignExchangeRateService.java
+++ b/src/main/java/ru/investbook/service/cbr/AbstractCbrForeignExchangeRateService.java
@@ -78,7 +78,7 @@ public abstract class AbstractCbrForeignExchangeRateService implements CbrForeig
             ForeignExchangeRateEntity entity = foreignExchangeRateConverter.toEntity(fxRate);
             foreignExchangeRateRepository.save(entity);
         } catch (Exception e) {
-            log.debug("Ошибка сохранения {}, может быть запись уже существует?", fxRate);
+            log.debug("Ошибка сохранения {}", fxRate);
         }
     }
 }

--- a/src/main/java/ru/investbook/web/forms/service/EventCashFlowFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/EventCashFlowFormsService.java
@@ -81,7 +81,7 @@ public class EventCashFlowFormsService {
 
     @Transactional
     public void save(EventCashFlowModel e) {
-        saveAndFlush(e.getPortfolio());
+        savePortfolio(e.getPortfolio());
         if (e.isAttachedToSecurity()) {
             saveSecurityEventCashFlow(e);
         } else {
@@ -90,7 +90,7 @@ public class EventCashFlowFormsService {
     }
 
     private void saveSecurityEventCashFlow(EventCashFlowModel e) {
-        int savedSecurityId = securityRepositoryHelper.saveAndFlushSecurity(requireNonNull(e.getAttachedSecurity()));
+        int savedSecurityId = securityRepositoryHelper.saveSecurity(requireNonNull(e.getAttachedSecurity()));
         SecurityEventCashFlowEntity entity = securityEventCashFlowRepository.save(
                 securityEventCashFlowConverter.toEntity(SecurityEventCashFlow.builder()
                         // no id(), it is always the new object
@@ -123,9 +123,9 @@ public class EventCashFlowFormsService {
         eventCashFlowRepository.flush();
     }
 
-    private void saveAndFlush(String portfolio) {
+    private void savePortfolio(String portfolio) {
         if (!portfolioRepository.existsById(portfolio)) {
-            portfolioRepository.saveAndFlush(
+            portfolioRepository.save(
                     portfolioConverter.toEntity(Portfolio.builder()
                             .id(portfolio)
                             .build()));

--- a/src/main/java/ru/investbook/web/forms/service/ForeignExchangeRateFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/ForeignExchangeRateFormsService.java
@@ -69,7 +69,7 @@ public class ForeignExchangeRateFormsService {
 
     @Transactional
     public void save(ForeignExchangeRateModel m) {
-        foreignExchangeRateRepository.saveAndFlush(
+        foreignExchangeRateRepository.save(
                 foreignExchangeRateConverter.toEntity(ForeignExchangeRate.builder()
                         .date(m.getDate())
                         .currencyPair((m.getBaseCurrency() + m.getQuoteCurrency()).toUpperCase())

--- a/src/main/java/ru/investbook/web/forms/service/PortfolioCashFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/PortfolioCashFormsService.java
@@ -75,7 +75,7 @@ public class PortfolioCashFormsService {
 
     @Transactional
     public void save(PortfolioCashModel m) {
-        saveAndFlush(m.getPortfolio());
+        savePortfolio(m.getPortfolio());
         PortfolioCash cash = PortfolioCash.builder()
                 .id(m.getId())
                 .portfolio(m.getPortfolio())
@@ -91,9 +91,9 @@ public class PortfolioCashFormsService {
         portfolioCashRepository.flush();
     }
 
-    private void saveAndFlush(String portfolio) {
+    private void savePortfolio(String portfolio) {
         if (!portfolioRepository.existsById(portfolio)) {
-            portfolioRepository.saveAndFlush(
+            portfolioRepository.save(
                     portfolioConverter.toEntity(Portfolio.builder()
                             .id(portfolio)
                             .build()));

--- a/src/main/java/ru/investbook/web/forms/service/PortfolioPropertyFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/PortfolioPropertyFormsService.java
@@ -81,7 +81,7 @@ public class PortfolioPropertyFormsService {
 
     @Transactional
     public void save(PortfolioPropertyModel m) {
-        saveAndFlush(m.getPortfolio());
+        savePortfolio(m.getPortfolio());
         PortfolioProperty.PortfolioPropertyBuilder builder = PortfolioProperty.builder()
                 .id(m.getId())
                 .portfolio(m.getPortfolio())
@@ -100,9 +100,9 @@ public class PortfolioPropertyFormsService {
         portfolioPropertyRepository.flush();
     }
 
-    private void saveAndFlush(String portfolio) {
+    private void savePortfolio(String portfolio) {
         if (!portfolioRepository.existsById(portfolio)) {
-            portfolioRepository.saveAndFlush(
+            portfolioRepository.save(
                     portfolioConverter.toEntity(Portfolio.builder()
                             .id(portfolio)
                             .build()));

--- a/src/main/java/ru/investbook/web/forms/service/SecurityDescriptionFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/SecurityDescriptionFormsService.java
@@ -67,7 +67,7 @@ public class SecurityDescriptionFormsService {
 
     @Transactional
     public void save(SecurityDescriptionModel m) {
-        int savedSecurityId = securityRepositoryHelper.saveAndFlushSecurity(m);
+        int savedSecurityId = securityRepositoryHelper.saveSecurity(m);
         securityDescriptionRepository.createOrUpdateSector(savedSecurityId, m.getSector());
     }
 

--- a/src/main/java/ru/investbook/web/forms/service/SecurityEventCashFlowFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/SecurityEventCashFlowFormsService.java
@@ -79,8 +79,8 @@ public class SecurityEventCashFlowFormsService {
 
     @Transactional
     public void save(SecurityEventCashFlowModel e) {
-        saveAndFlush(e.getPortfolio());
-        int savedSecurityId = securityRepositoryHelper.saveAndFlushSecurity(e);
+        savePortfolio(e.getPortfolio());
+        int savedSecurityId = securityRepositoryHelper.saveSecurity(e);
         SecurityEventCashFlowBuilder builder = SecurityEventCashFlow.builder()
                 .portfolio(e.getPortfolio())
                 .timestamp(e.getDate().atTime(e.getTime()).atZone(zoneId).toInstant())
@@ -109,9 +109,9 @@ public class SecurityEventCashFlowFormsService {
         securityEventCashFlowRepository.flush();
     }
 
-    private void saveAndFlush(String portfolio) {
+    private void savePortfolio(String portfolio) {
         if (!portfolioRepository.existsById(portfolio)) {
-            portfolioRepository.saveAndFlush(
+            portfolioRepository.save(
                     portfolioConverter.toEntity(Portfolio.builder()
                             .id(portfolio)
                             .build()));

--- a/src/main/java/ru/investbook/web/forms/service/SecurityQuoteFormsService.java
+++ b/src/main/java/ru/investbook/web/forms/service/SecurityQuoteFormsService.java
@@ -69,8 +69,8 @@ public class SecurityQuoteFormsService {
 
     @Transactional
     public void save(SecurityQuoteModel e) {
-        int savedSecurityId = securityRepositoryHelper.saveAndFlushSecurity(e);
-        SecurityQuoteEntity entity = securityQuoteRepository.saveAndFlush(
+        int savedSecurityId = securityRepositoryHelper.saveSecurity(e);
+        SecurityQuoteEntity entity = securityQuoteRepository.save(
                 securityQuoteConverter.toEntity(SecurityQuote.builder()
                         .id(e.getId())
                         .security(savedSecurityId)

--- a/src/main/java/ru/investbook/web/forms/service/SecurityRepositoryHelper.java
+++ b/src/main/java/ru/investbook/web/forms/service/SecurityRepositoryHelper.java
@@ -52,8 +52,8 @@ public class SecurityRepositoryHelper {
      * Generate securityId if needed, save security to DB, update securityId for model if needed
      * @return saved security id
      */
-    public int saveAndFlushSecurity(SecurityDescriptionModel m) {
-        int savedSecurityId = saveAndFlush(m.getSecurityId(), m.getSecurityIsin(), m.getSecurityName(), m.getSecurityType());
+    public int saveSecurity(SecurityDescriptionModel m) {
+        int savedSecurityId = saveSecurity(m.getSecurityId(), m.getSecurityIsin(), m.getSecurityName(), m.getSecurityType());
         m.setSecurityId(savedSecurityId);
         return savedSecurityId;
     }
@@ -62,62 +62,62 @@ public class SecurityRepositoryHelper {
      * Generate securityId if needed, save security to DB, update securityId for model if needed
      * @return saved security id
      */
-    public int saveAndFlushSecurity(EventCashFlowModel.AttachedSecurity s) {
+    public int saveSecurity(EventCashFlowModel.AttachedSecurity s) {
         // EventCashFlowModel. AttachToSecurity может содержать только SHARE или BOND.
         // Тип SHARE захардкожен, тип может быть ошибочен, но для текущего алгоритма сохранения ЦБ этого типа достаточно
-        return saveAndFlush(s.getSecurityIsin(), s.getSecurityName(), SecurityType.SHARE);
+        return saveSecurity(s.getSecurityIsin(), s.getSecurityName(), SecurityType.SHARE);
     }
 
     /**
      * Generate securityId if needed, save security to DB, update securityId for model if needed
      * @return saved security id
      */
-    public int saveAndFlushSecurity(SecurityEventCashFlowModel m) {
-        return saveAndFlush(m.getSecurityIsin(), m.getSecurityName(), m.getSecurityType());
+    public int saveSecurity(SecurityEventCashFlowModel m) {
+        return saveSecurity(m.getSecurityIsin(), m.getSecurityName(), m.getSecurityType());
     }
 
     /**
      * Generate securityId if needed, save security to DB, update securityId for model if needed
      * @return saved security id
      */
-    public int saveAndFlushSecurity(SecurityQuoteModel m) {
-        return saveAndFlush(m.getSecurityIsin(), m.getSecurityName(), m.getSecurityType());
+    public int saveSecurity(SecurityQuoteModel m) {
+        return saveSecurity(m.getSecurityIsin(), m.getSecurityName(), m.getSecurityType());
     }
 
     /**
      * Generate securityId if needed, save security to DB, update securityId for model if needed
      * @return saved security id
      */
-    public int saveAndFlushSecurity(TransactionModel m) {
-        return saveAndFlush(m.getSecurityIsin(), m.getSecurityName(), m.getSecurityType());
+    public int saveSecurity(TransactionModel m) {
+        return saveSecurity(m.getSecurityIsin(), m.getSecurityName(), m.getSecurityType());
     }
 
     /**
      * Generate securityId if needed, save security to DB, update securityId for model if needed
      * @return saved security id
      */
-    public int saveAndFlushSecurity(SplitModel m) {
-        return saveAndFlush(m.getSecurityIsin(), m.getSecurityName(), SecurityType.SHARE);
+    public int saveSecurity(SplitModel m) {
+        return saveSecurity(m.getSecurityIsin(), m.getSecurityName(), SecurityType.SHARE);
     }
 
     /**
      * @return securityId from DB
      */
-    private int saveAndFlush(Integer securityId, String isin, String securityName, SecurityType securityType) {
+    private int saveSecurity(Integer securityId, String isin, String securityName, SecurityType securityType) {
         SecurityEntity security = ofNullable(securityId)
                 .flatMap(securityRepository::findById)
                 .or(() -> findSecurity(isin, securityName, securityType))
                 .orElseGet(SecurityEntity::new);
-        return saveAndFlush(security, isin, securityName, securityType, true);
+        return saveSecurity(security, isin, securityName, securityType, true);
     }
 
-    private int saveAndFlush(String isin, String securityName, SecurityType securityType) {
+    private int saveSecurity(String isin, String securityName, SecurityType securityType) {
         SecurityEntity security = findSecurity(isin, securityName, securityType)
                 .orElseGet(SecurityEntity::new);
-        return saveAndFlush(security, isin, securityName, securityType, false);
+        return saveSecurity(security, isin, securityName, securityType, false);
     }
 
-    private int saveAndFlush(SecurityEntity security, String isin, String securityName,
+    private int saveSecurity(SecurityEntity security, String isin, String securityName,
                              SecurityType securityType, boolean forceRewriteByEmptyIsin) {
         isin = validateIsin(isin);
         if (isin == null && !forceRewriteByEmptyIsin) {
@@ -140,7 +140,7 @@ public class SecurityRepositoryHelper {
                 security.setName(securityName);
             }
         }
-        security = securityRepository.saveAndFlush(security);
+        security = securityRepository.save(security);
         return security.getId();
     }
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -22,6 +22,7 @@
 #spring.datasource.username = root
 #spring.datasource.password = 123456
 #spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
+#logging.level.org.mariadb.jdbc.message.server.ErrorPacket=ERROR
 
 # H2
 spring.datasource.url=jdbc:h2:file:~/investbook3-test;mode=mysql;non_keywords=value

--- a/src/main/resources/application-mariadb.properties
+++ b/src/main/resources/application-mariadb.properties
@@ -3,3 +3,4 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MariaDBDialect
 spring.datasource.username=root
 spring.datasource.password=123456
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
+logging.level.org.mariadb.jdbc.message.server.ErrorPacket=ERROR

--- a/src/test/java/ru/investbook/api/AbstractEntityRepositoryServiceTest.java
+++ b/src/test/java/ru/investbook/api/AbstractEntityRepositoryServiceTest.java
@@ -1,0 +1,76 @@
+/*
+ * InvestBook
+ * Copyright (C) 2024  Spacious Team <spacious-team@ya.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ru.investbook.api;
+
+import org.junit.jupiter.api.Test;
+import org.spacious_team.broker.pojo.Security;
+import org.spacious_team.broker.pojo.SecurityType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Duration;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+/**
+ * Performance test
+ */
+@SpringBootTest(properties = "spring.datasource.url=jdbc:h2:mem:testdb;mode=mysql;non_keywords=value")
+class AbstractEntityRepositoryServiceTest {
+
+    @Autowired
+    private SecurityRestController service;
+    private final Random random = new Random();
+    private final AtomicInteger i = new AtomicInteger();
+
+    @Test
+    void insert() {
+        test("insert()", service::insert, false);
+        test("insert()", service::insert, false);
+        test("insert()", service::insert, true);
+        test("insert()", service::insert, true);
+    }
+
+    @Test
+    void create() {
+        test("create()", service::create, false);
+        test("create()", service::create, false);
+        test("create()", service::create, true);
+        test("create()", service::create, true);
+    }
+
+    void test(String name, Consumer<Security> consumer, boolean isIdNull) {
+        long t0 = System.nanoTime();
+        for (int i = 0; i < 1_000; i++) {
+            Security security = createSecurity(isIdNull);
+            consumer.accept(security);
+        }
+        String isIdNullMsg = isIdNull ? "without predefined ID" : "with always same ID (insert error)";
+        System.out.println("Total time " + name + " (" + isIdNullMsg + "):" + Duration.ofNanos(System.nanoTime() - t0));
+    }
+
+    Security createSecurity(boolean isIdNull) {
+        return Security.builder()
+                .id(isIdNull ? null : 1)
+                .type(SecurityType.STOCK)
+                .name(String.valueOf(i.getAndIncrement()))
+                .build();
+    }
+}

--- a/src/test/java/ru/investbook/api/AbstractEntityRepositoryServiceTest.java
+++ b/src/test/java/ru/investbook/api/AbstractEntityRepositoryServiceTest.java
@@ -49,11 +49,11 @@ class AbstractEntityRepositoryServiceTest {
     }
 
     @Test
-    void create() {
-        test("create()", service::create, false);
-        test("create()", service::create, false);
-        test("create()", service::create, true);
-        test("create()", service::create, true);
+    void createIfAbsent() {
+        test("createIfAbsent()", service::createIfAbsent, false);
+        test("createIfAbsent()", service::createIfAbsent, false);
+        test("createIfAbsent()", service::createIfAbsent, true);
+        test("createIfAbsent()", service::createIfAbsent, true);
     }
 
     void test(String name, Consumer<Security> consumer, boolean isIdNull) {


### PR DESCRIPTION
В результате изменений PR количество SELECT-ов снижено в 2 раза, количество транзакций снизилось в 1,5 раза. Время загрузки изменилось не существенно.

До оптимизации:
| | Время загрузки, сек | select count | update count  | other_commands count  | commit count  | rollback count 
| -- | -- | --| -- | -- | -- | -- |
| Новые данные | 13 | 75254 | 26864 | 171500 | 144863 | 14100
| Дубли данных | 18 | 77035 |  25716 | 170722 | 107770 | 51432

После оптимизации:
| | Время загрузки, сек | select count | update count  | other_commands count  | commit count  | rollback count 
| -- | -- | --| -- | -- | -- | -- |
Новые данные | 11 | 32388 | 25693 | 175318 |  102480 | 11758
Дубли данных |  17 | 31418 | 22294 | 167977 | 62834 | 44588

Тестирование выполнено на 626 отчетах брокера ПСБ. Данные загружались 2 раза: один раз в чистую БД, а затем поверх уже прогруженных данных загружались снова те же данные.

Время загрузки замерялось на H2 (основная СУБД). Количество запросов и коммитов получено с MariaDB (отображает статистику по количеству запросов) запросом [статистики](https://mariadb.com/kb/en/information-schema-user_statistics-table/)
```sql
SET GLOBAL userstat=1;
SELECT
    user,
    select_commands,
    update_commands,
    other_commands,
    commit_transactions,
    rollback_transactions
FROM 
    information_schema.user_statistics;
```

Тестовый ПК Intel Core i5 12400F.