### PR TITLE
Исправить работу с non-ascii символами в docker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -514,12 +514,12 @@
                                 <env>
                                     <BPE_LANG>C.UTF-8</BPE_LANG>
                                 </env>
-                                <buildpacks>
-                                    <!-- Defines available bellsoft-liberica java versions from
-                                    https://github.com/paketo-buildpacks/java/releases
-                                    JRE with ${java.version} will be selected automatically when available -->
-                                    <buildpack>docker.io/paketobuildpacks/java:18.8.0</buildpack>
-                                </buildpacks>
+                                <!-- Replace with 'paketobuildpacks/builder-jammy-java-tiny' if resolved
+                                     https://github.com/paketo-buildpacks/jammy-tiny-stack/issues/202 -->
+                                <!-- Defines available bellsoft-liberica java versions from
+                                     https://github.com/paketo-buildpacks/builder-jammy-base/releases
+                                     JRE with ${java.version} will be selected automatically when available -->
+                                <builder>paketobuildpacks/builder-jammy-base:0.4.418</builder>
                             </image>
                             <docker>
                                 <publishRegistry>

--- a/src/main/java/ru/investbook/loadingpage/LoadingPageHttpServerImpl.java
+++ b/src/main/java/ru/investbook/loadingpage/LoadingPageHttpServerImpl.java
@@ -38,7 +38,6 @@ import static ru.investbook.loadingpage.LoadingPageHttpServerHelper.*;
 
 @Slf4j
 public class LoadingPageHttpServerImpl implements LoadingPageHttpServer {
-    public static final int DEFAULT_CLOSE_DELAY_SEC = 20;
     private volatile @Nullable HttpServer server;
 
     @Override
@@ -66,7 +65,7 @@ public class LoadingPageHttpServerImpl implements LoadingPageHttpServer {
     public void close() {
         if (nonNull(server)) {
             //noinspection DataFlowIssue
-            server.stop(DEFAULT_CLOSE_DELAY_SEC);
+            server.stop(0);
             server = null;
             log.info("Loading page http server is stopped");
         }


### PR DESCRIPTION
1. При работе в docker контейнере не удается загрузить отчеты брокера.

Заведена заявка https://github.com/paketo-buildpacks/jammy-tiny-stack/issues/202

До ее решения builder переключен с дефолтного (`builder-jammy-java-tiny`) на `builder-jammy-base`. Это заменяет runtime образ с [run-jammy-tiny](https://github.com/paketo-buildpacks/jammy-tiny-stack) на [run-jammy-base](https://github.com/paketo-buildpacks/jammy-base-stack) и решает проблему.

2. Также в MR заменяет buildpack `docker.io/paketobuildpacks/java` на builder (пока на `paketobuildpacks/builder-jammy-base`). В состав builder-а входит `docker.io/paketobuildpacks/java` нужной версии, а также входят другие buildpack-и конкретных версий. Ранее версия всех builpack-ов, кроме java, зависила от момента сборки. Конкретные версии должны повысить воспроизводимость сборки при сборке в разные моменты времени.