### PR TITLE
Автоматическая публикация MSI и ZIP 

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -15,12 +15,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           java-version: '24'
           distribution: 'liberica'
           cache: maven
+
       - name: Publish
         run: mvn --batch-mode --activate-profiles docker --define no-zip spring-boot:build-image
         env:

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,0 +1,63 @@
+# https://github.com/softprops/action-gh-release#%EF%B8%8F-uploading-release-assets
+
+name: Attach Installers to Release Assets
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish-msi-and-zip:
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '24'
+          distribution: 'liberica'
+          cache: maven
+
+      - name: Set up Wix
+        run: |
+          dotnet tool install --global wix --version 6.0.1
+          wix extension add -g WixToolset.Util.wixext/6.0.1
+          wix extension add -g WixToolset.Ui.wixext/6.0.1
+
+      - name: Build
+        run: mvn --batch-mode --activate-profiles msi package
+
+      - name: Attach MSI and ZIP to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            target/investbook-*.zip
+            target/jpackage/output/investbook-*.msi 
+
+  publish-deb:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      # TODO
+
+  publish-rpm:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      # TODO
+
+  publish-mac:
+
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      # TODO

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -75,8 +75,8 @@ dotnet tool list --global
 ```shell
 ./mvnw package
 ```
-Zip-архив может быть [установлен](install-on-linux.md) на Linux и Mac. На Windows рекомендуется
-[установка](install-on-windows.md) через msi-инсталлятор.
+Zip-архив собирается на любой ОС в папке `target/`.
+Если команда запущена под Windows, то соберется msi-инсталлятор в папке `target/jpackage/output/`.
 
 ### Обновление maven wrapper
 Если требуется обновить maven wrapper, выполнить

--- a/pom.xml
+++ b/pom.xml
@@ -438,11 +438,14 @@
             </build>
         </profile>
         <profile>
-            <id>jpackage</id>
+            <id>msi</id>
             <activation>
                 <os>
                     <family>windows</family>
                 </os>
+                <property>
+                    <name>!no-msi</name>
+                </property>
             </activation>
             <build>
                 <plugins>


### PR DESCRIPTION
После публикации релиза на GitHub настроена автоматическая сборка msi и zip (portable утсановка) и их публикация в release assets.

Closes #621 
Relates #641 