### PR TITLE
Поправить парсер отчета ВТБ 2026

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>com.github.spacious-team</groupId>
             <artifactId>broker-report-parser-api</artifactId>
-            <version>65b21c3a66</version>
+            <version>3bac204a7e</version>
         </dependency>
         <dependency>
             <groupId>com.github.spacious-team</groupId>

--- a/src/main/java/ru/investbook/parser/BrokerReportParserServiceImpl.java
+++ b/src/main/java/ru/investbook/parser/BrokerReportParserServiceImpl.java
@@ -151,7 +151,7 @@ public class BrokerReportParserServiceImpl implements BrokerReportParserService 
                         .stream())
                 .findAny()
                 .orElseThrow(() -> new IllegalArgumentException("Файл " + fileName +
-                        " не является отчетом брокера " + providedByBroker));
+                        " не является отчетом брокера '" + providedByBroker + "'"));
     }
 
     private Collection<BrokerReportFactory> findBrokerReportFactory(String broker) {

--- a/src/main/java/ru/investbook/parser/SingleAbstractReportTable.java
+++ b/src/main/java/ru/investbook/parser/SingleAbstractReportTable.java
@@ -43,8 +43,28 @@ public abstract class SingleAbstractReportTable<R> extends AbstractReportTable<R
                               String tableName,
                               @Nullable String tableFooter,
                               Class<T> headerDescription,
-                              int headersRowCount) {
-        super(report, tableName, tableFooter, headerDescription, headersRowCount);
+                              int headerRowsCount) {
+        super(report, tableName, tableFooter, headerDescription, headerRowsCount);
+    }
+
+    protected <T extends Enum<T> & TableHeaderColumn>
+    SingleAbstractReportTable(SingleBrokerReport report,
+                              String tableName,
+                              int tableNameRowCount,
+                              @Nullable String tableFooter,
+                              Class<T> headerDescription,
+                              int headerRowsCount) {
+        super(report, tableName, tableNameRowCount, tableFooter, headerDescription, headerRowsCount);
+    }
+
+    protected <T extends Enum<T> & TableHeaderColumn>
+    SingleAbstractReportTable(SingleBrokerReport report,
+                              String tableName,
+                              int tableNameRowCount,
+                              String firstDataRow,
+                              @Nullable String tableFooter,
+                              Class<T> headerDescription) {
+        super(report, tableName, tableNameRowCount, firstDataRow, tableFooter, headerDescription);
     }
 
     protected <T extends Enum<T> & TableHeaderColumn>
@@ -60,11 +80,31 @@ public abstract class SingleAbstractReportTable<R> extends AbstractReportTable<R
                               Predicate<String> tableNameFinder,
                               @Nullable Predicate<String> tableFooterFinder,
                               Class<T> headerDescription,
-                              int headersRowCount) {
-        super(report, tableNameFinder, tableFooterFinder, headerDescription, headersRowCount);
+                              int headerRowsCount) {
+        super(report, tableNameFinder, tableFooterFinder, headerDescription, headerRowsCount);
     }
 
-    public <T extends Enum<T> & TableHeaderColumn>
+    protected <T extends Enum<T> & TableHeaderColumn>
+    SingleAbstractReportTable(SingleBrokerReport report,
+                              Predicate<String> tableNameFinder,
+                              int tableNameRowCount,
+                              @Nullable Predicate<String> tableFooterFinder,
+                              Class<T> headerDescription,
+                              int headerRowsCount) {
+        super(report, tableNameFinder, tableNameRowCount, tableFooterFinder, headerDescription, headerRowsCount);
+    }
+
+    protected <T extends Enum<T> & TableHeaderColumn>
+    SingleAbstractReportTable(SingleBrokerReport report,
+                              Predicate<String> tableNameFinder,
+                              int tableNameRowCount,
+                              Predicate<String> firstDataRowFinder,
+                              @Nullable Predicate<String> tableFooterFinder,
+                              Class<T> headerDescription) {
+        super(report, tableNameFinder, tableNameRowCount, firstDataRowFinder, tableFooterFinder, headerDescription);
+    }
+
+    protected <T extends Enum<T> & TableHeaderColumn>
     SingleAbstractReportTable(SingleBrokerReport report,
                               String providedTableName,
                               String namelessTableFirstLine,
@@ -73,14 +113,24 @@ public abstract class SingleAbstractReportTable<R> extends AbstractReportTable<R
         super(report, providedTableName, namelessTableFirstLine, tableFooter, headerDescription);
     }
 
-    public <T extends Enum<T> & TableHeaderColumn>
+    protected <T extends Enum<T> & TableHeaderColumn>
     SingleAbstractReportTable(SingleBrokerReport report,
                               String providedTableName,
                               String namelessTableFirstLine,
                               @Nullable String tableFooter,
                               Class<T> headerDescription,
-                              int headersRowCount) {
-        super(report, providedTableName, namelessTableFirstLine, tableFooter, headerDescription, headersRowCount);
+                              int headerRowsCount) {
+        super(report, providedTableName, namelessTableFirstLine, tableFooter, headerDescription, headerRowsCount);
+    }
+
+    protected <T extends Enum<T> & TableHeaderColumn>
+    SingleAbstractReportTable(SingleBrokerReport report,
+                              String providedTableName,
+                              String headerRowPrefix,
+                              String firstDataRowPrefix,
+                              @Nullable String tableFooter,
+                              Class<T> headerDescription) {
+        super(report, providedTableName, headerRowPrefix, firstDataRowPrefix, tableFooter, headerDescription);
     }
 
     protected <T extends Enum<T> & TableHeaderColumn>
@@ -98,8 +148,18 @@ public abstract class SingleAbstractReportTable<R> extends AbstractReportTable<R
                               Predicate<String> namelessTableFirstLineFinder,
                               @Nullable Predicate<String> tableFooterFinder,
                               Class<T> headerDescription,
-                              int headersRowCount) {
-        super(report, providedTableName, namelessTableFirstLineFinder, tableFooterFinder, headerDescription, headersRowCount);
+                              int headerRowsCount) {
+        super(report, providedTableName, namelessTableFirstLineFinder, tableFooterFinder, headerDescription, headerRowsCount);
+    }
+
+    protected <T extends Enum<T> & TableHeaderColumn>
+    SingleAbstractReportTable(SingleBrokerReport report,
+                              String providedTableName,
+                              Predicate<String> headerRowFinder,
+                              Predicate<String> firstDataRowFinder,
+                              @Nullable Predicate<String> tableFooterFinder,
+                              Class<T> headerDescription) {
+        super(report, providedTableName, headerRowFinder, firstDataRowFinder, tableFooterFinder, headerDescription);
     }
 
     @Override

--- a/src/main/java/ru/investbook/parser/psb/AccountPropertyTable.java
+++ b/src/main/java/ru/investbook/parser/psb/AccountPropertyTable.java
@@ -63,7 +63,7 @@ public class AccountPropertyTable extends SingleInitializableReportTable<Account
 
     public static Table getSummaryTable(BrokerReport report, String tableFooterString) {
         Table table = report.getReportPage()
-                .create(SUMMARY_TABLE, tableFooterString, SummaryTableHeader.class);
+                .createTable(SUMMARY_TABLE, 1, tableFooterString, SummaryTableHeader.class, 1);
         if (table.isEmpty()) {
             throw new IllegalArgumentException("Таблица '" + SUMMARY_TABLE + "' не найдена");
         }

--- a/src/main/java/ru/investbook/parser/psb/DerivativeCashFlowTable.java
+++ b/src/main/java/ru/investbook/parser/psb/DerivativeCashFlowTable.java
@@ -60,8 +60,8 @@ public class DerivativeCashFlowTable extends SingleAbstractReportTable<SecurityE
 
     private boolean hasOpenContract() {
         contractCount = getReport().getReportPage()
-                .create(TABLE2_NAME, TABLE_END_TEXT, ContractCountTableHeader.class)
-                .excludeTotalRow()
+                .createTable(TABLE2_NAME, 1, TABLE_END_TEXT, ContractCountTableHeader.class, 1)
+                .excludeLastRow()
                 .getData(getReport(), DerivativeCashFlowTable::getCount)
                 .stream()
                 .filter(e -> e.getValue() != 0)

--- a/src/main/java/ru/investbook/parser/psb/SecurityTransactionTable.java
+++ b/src/main/java/ru/investbook/parser/psb/SecurityTransactionTable.java
@@ -73,8 +73,8 @@ public class SecurityTransactionTable extends SingleInitializableReportTable<Sec
 
     private List<SecurityTransaction> parseTable(String tableName) {
         return getReport().getReportPage()
-                .create(tableName, TABLE_END_TEXT, TransactionTableHeader.class)
-                .excludeTotalRow()
+                .createTable(tableName, 1, TABLE_END_TEXT, TransactionTableHeader.class, 1)
+                .excludeLastRow()
                 .getData(getReport(), this::getTransaction);
     }
 

--- a/src/main/java/ru/investbook/parser/psb/foreignmarket/ForeignExchangeCashTable.java
+++ b/src/main/java/ru/investbook/parser/psb/foreignmarket/ForeignExchangeCashTable.java
@@ -25,7 +25,7 @@ import org.spacious_team.table_wrapper.api.Table;
 import org.spacious_team.table_wrapper.api.TableRow;
 import ru.investbook.parser.SingleBrokerReport;
 import ru.investbook.parser.SingleInitializableReportTable;
-import ru.investbook.parser.psb.AccountPropertyTable;
+import ru.investbook.parser.psb.AccountPropertyTable.SummaryTableHeader;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -39,7 +39,7 @@ import static ru.investbook.parser.psb.foreignmarket.ForeignExchangeAccountPrope
 @Slf4j
 public class ForeignExchangeCashTable extends SingleInitializableReportTable<AccountCash> {
 
-    private final AccountPropertyTable.SummaryTableHeader[] CURRENCIES = new AccountPropertyTable.SummaryTableHeader[]{ RUB, USD, EUR, GBP, CHF };
+    private final SummaryTableHeader[] CURRENCIES = new SummaryTableHeader[]{ RUB, USD, EUR, GBP, CHF };
 
     public ForeignExchangeCashTable(SingleBrokerReport report) {
         super(report);
@@ -53,7 +53,7 @@ public class ForeignExchangeCashTable extends SingleInitializableReportTable<Acc
             return emptyList();
         }
         Collection<AccountCash> cashes = new ArrayList<>();
-        for (AccountPropertyTable.SummaryTableHeader currency : CURRENCIES) {
+        for (SummaryTableHeader currency : CURRENCIES) {
             @Nullable BigDecimal cash = row.getBigDecimalCellValueOrDefault(currency, null);
             if (cash != null) {
                 cashes.add(AccountCash.builder()
@@ -70,7 +70,7 @@ public class ForeignExchangeCashTable extends SingleInitializableReportTable<Acc
 
     private Table getSummaryTable() {
         Table table = getReport().getReportPage()
-                .create(SUMMARY_TABLE, ASSETS, AccountPropertyTable.SummaryTableHeader.class);
+                .createTable(SUMMARY_TABLE, 1, ASSETS, SummaryTableHeader.class, 1);
         if (table.isEmpty()) {
             throw new IllegalArgumentException("Таблица '" + SUMMARY_TABLE + "' не найдена");
         }

--- a/src/main/java/ru/investbook/parser/uralsib/AssetsTable.java
+++ b/src/main/java/ru/investbook/parser/uralsib/AssetsTable.java
@@ -62,10 +62,10 @@ public class AssetsTable extends SingleInitializableReportTable<AccountProperty>
         try {
             SingleBrokerReport report = getReport();
             Table table = report.getReportPage()
-                    .createNameless(ASSETS_TABLE, TABLE_FIRST_HEADER_LINE, SummaryTableHeader.class, 3);
+                    .createNamelessTable(ASSETS_TABLE, TABLE_FIRST_HEADER_LINE, null, SummaryTableHeader.class, 3);
             if (table.isEmpty()) {
                 table = report.getReportPage()
-                        .createNameless(ASSETS_TABLE, TABLE_SECOND_HEADER_LINE, SummaryTableHeader.class, 2);
+                        .createNamelessTable(ASSETS_TABLE, TABLE_SECOND_HEADER_LINE, null, SummaryTableHeader.class, 2);
             }
             if (table.isEmpty()) {
                 log.debug("Таблица '{}' не найдена", ASSETS_TABLE);

--- a/src/main/java/ru/investbook/parser/vtb/VtbAccountPropertyTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbAccountPropertyTable.java
@@ -36,6 +36,7 @@ public class VtbAccountPropertyTable extends SingleInitializableReportTable<Acco
 
     private static final String TOTAL_ASSETS1 = "ОЦЕНКА активов (по курсу ЦБ с учётом незавершенных сделок)";
     private static final String TOTAL_ASSETS2 = "ОЦЕНКА активов по Kурсу с учётом незавершенных сделок";
+    private static final String TOTAL_ASSETS3 = "ОЦЕНКА активов по Курсу с учетом незавершенных сделок";
 
     public VtbAccountPropertyTable(SingleBrokerReport report) {
         super(report);
@@ -61,6 +62,9 @@ public class VtbAccountPropertyTable extends SingleInitializableReportTable<Acco
         @Nullable Object value = getReport().getReportPage().getNextColumnValue(TOTAL_ASSETS1);
         if (value == null) {
             value = getReport().getReportPage().getNextColumnValue(TOTAL_ASSETS2);
+        }
+        if (value == null) {
+            value = getReport().getReportPage().getNextColumnValue(TOTAL_ASSETS3);
         }
         return BigDecimal.valueOf(
                 Double.parseDouble(String.valueOf(value)));

--- a/src/main/java/ru/investbook/parser/vtb/VtbBrokerReport.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbBrokerReport.java
@@ -58,7 +58,7 @@ public class VtbBrokerReport extends AbstractExcelBrokerReport {
     }
 
     private static void checkReportFormat(String excelFileName, ReportPage reportPage) {
-        if (reportPage.findByPrefix(UNIQ_TEXT, 1, 2) == TableCellAddress.NOT_FOUND) {
+        if (reportPage.findByPrefix(UNIQ_TEXT, 0, 2) == TableCellAddress.NOT_FOUND) {
             throw new RuntimeException("В файле " + excelFileName + " не содержится отчет брокера ВТБ");
         }
     }
@@ -85,7 +85,7 @@ public class VtbBrokerReport extends AbstractExcelBrokerReport {
 
     private static Instant getReportEndDateTime(ReportPage reportPage) {
         try {
-            TableCellAddress address = reportPage.findByPrefix(REPORT_DATE_MARKER, 1, 2);
+            TableCellAddress address = reportPage.findByPrefix(REPORT_DATE_MARKER, 0, 2);
             @SuppressWarnings({"nullness", "DataFlowIssue"})
             String value = reportPage.getCell(address)
                     .getStringValue()

--- a/src/main/java/ru/investbook/parser/vtb/VtbCashTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbCashTable.java
@@ -35,6 +35,7 @@ import ru.investbook.parser.SingleBrokerReport;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 
 @Slf4j
 public class VtbCashTable extends SingleAbstractReportTable<AccountCash> {
@@ -47,9 +48,10 @@ public class VtbCashTable extends SingleAbstractReportTable<AccountCash> {
     protected VtbCashTable(SingleBrokerReport report) {
         super(report,
                 cell -> cell.startsWith(TABLE_NAME) || cell.startsWith(TABLE_NAME_WITH_YO),
+                1,
+                cell -> Objects.equals(cell, "RUR"),
                 cell -> cell.startsWith(TABLE_FOOTER),
-                VtbCashTableHeader.class,
-                2);
+                VtbCashTableHeader.class);
     }
 
     @Override
@@ -83,16 +85,19 @@ public class VtbCashTable extends SingleAbstractReportTable<AccountCash> {
         STOCK_MARKET(
                 OptionalTableColumn.of(
                         AnyOfTableColumn.of(
+                                MultiLineTableColumn.of("Исходящий остаток", "основной рынок"),
                                 MultiLineTableColumn.of("Исходящий остаток", "", "основной рынок"),
                                 MultiLineTableColumn.of("Исходящий остаток", "площадка", "основной рынок")))),
         FORTS_MARKET(
                 OptionalTableColumn.of(
                         AnyOfTableColumn.of(
+                                MultiLineTableColumn.of("Исходящий остаток", "срочный рынок"),
                                 MultiLineTableColumn.of("Исходящий остаток", "", "срочный рынок"),
                                 MultiLineTableColumn.of("Исходящий остаток", "площадка", "срочный рынок")))),
         NON_MARKET(
                 OptionalTableColumn.of(
                         AnyOfTableColumn.of(
+                                MultiLineTableColumn.of("Исходящий остаток", "внебирж. рынок"),
                                 MultiLineTableColumn.of("Исходящий остаток", "", "внебирж. рынок"),
                                 MultiLineTableColumn.of("Исходящий остаток", "площадка", "внебирж. рынок"))));
 

--- a/src/main/java/ru/investbook/parser/vtb/VtbCashTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbCashTable.java
@@ -49,7 +49,7 @@ public class VtbCashTable extends SingleAbstractReportTable<AccountCash> {
                 cell -> cell.startsWith(TABLE_NAME) || cell.startsWith(TABLE_NAME_WITH_YO),
                 cell -> cell.startsWith(TABLE_FOOTER),
                 VtbCashTableHeader.class,
-                3);
+                2);
     }
 
     @Override

--- a/src/main/java/ru/investbook/parser/vtb/VtbDerivativeCashFlowTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbDerivativeCashFlowTable.java
@@ -48,7 +48,7 @@ public class VtbDerivativeCashFlowTable extends AbstractVtbCashFlowTable<Securit
         @SuppressWarnings("method.invocation")
         SingleBrokerReport report = getReport();
         List<String> contracts = report.getReportPage()
-                .create(TABLE_NAME, OpenContractsTableHeader.class)
+                .createTable(TABLE_NAME, 1, null, OpenContractsTableHeader.class, 1)
                 .getData(row -> row.getStringCellValue(CONTRACT));
         this.contractId = (contracts.size() == 1) ?
                 report.getSecurityRegistrar().declareDerivative(requireNonNull(contracts.getFirst())) :

--- a/src/main/java/ru/investbook/parser/vtb/VtbForeignExchangeTransactionTable.java
+++ b/src/main/java/ru/investbook/parser/vtb/VtbForeignExchangeTransactionTable.java
@@ -59,7 +59,7 @@ public class VtbForeignExchangeTransactionTable extends SingleInitializableRepor
 
     private Collection<ForeignExchangeTransaction> parseTable(String tableName) {
         return getReport().getReportPage()
-                .create(tableName, FxTransactionTableHeader.class)
+                .createTable(tableName, 1, null, FxTransactionTableHeader.class, 1)
                 .getData(getReport(), this::parseRow);
     }
 

--- a/src/main/java/ru/investbook/service/Sp500OfficialService.java
+++ b/src/main/java/ru/investbook/service/Sp500OfficialService.java
@@ -59,7 +59,7 @@ public class Sp500OfficialService implements Sp500Service {
     private void updateBy(InputStream inputStream) throws IOException {
         Workbook book = new HSSFWorkbook(inputStream);
         new ExcelSheet(book.getSheetAt(0))
-                .createNameless("Effective date", TableHeader.class)
+                .createNamelessTable("SP500 Table", "Effective date", null, TableHeader.class, 1)
                 .stream()
                 .filter(Objects::nonNull)
                 .map(Sp500OfficialService::getIndexValue)

--- a/src/main/java/ru/investbook/service/cbr/CbrForeignExchangeRateServiceExcelImpl.java
+++ b/src/main/java/ru/investbook/service/cbr/CbrForeignExchangeRateServiceExcelImpl.java
@@ -76,7 +76,7 @@ public class CbrForeignExchangeRateServiceExcelImpl extends AbstractCbrForeignEx
         requireNonNull(resource, "Не удалось скачать курсы валют");
         Workbook book = new XSSFWorkbook(resource.getInputStream());
         new ExcelSheet(book.getSheetAt(0))
-                .createNameless("data", TableHeader.class)
+                .createNamelessTable("CBR FX Rate", "data", null, TableHeader.class, 1)
                 .stream()
                 .filter(Objects::nonNull)
                 .map(row -> getRate(requireNonNull(row), currencyPair))


### PR DESCRIPTION
По #668 сделаны не все правки. Этот PR вносит дополнительные правки.

Таблица "Отчет об остатках денежных средств" теперь вместо 3 строк содержит 2. Существенно доработаны https://github.com/spacious-team/table-wrapper-api и https://github.com/spacious-team/broker-report-parser-api для возможности поддержки переменного количества строк в заголовках таблиц.